### PR TITLE
Mark a `max-payne_[73602a7f]` mirror as missing due to 404

### DIFF
--- a/content/Unreal Tournament 2004/Models/M/7/3/602a7f/max-payne_[73602a7f].yml
+++ b/content/Unreal Tournament 2004/Models/M/7/3/602a7f/max-payne_[73602a7f].yml
@@ -33,7 +33,7 @@ downloads:
 - url: "https://files.vohzd.com/unrealarchive/Unreal%20Tournament%202004/Models/M/7/3/602a7f/maxpayne2_ut2k3.zip"
   main: false
   repack: false
-  state: "OK"
+  state: "MISSING"
 - url: "https://unreal-archive-files.eu-central-1.linodeobjects.com/Unreal%20Tournament%202004/Models/M/7/3/602a7f/maxpayne2_ut2k3.zip"
   main: false
   repack: false


### PR DESCRIPTION
It appears this mirror is no longer hosting this file 