### PR TITLE
Separation of LowGrav Instagib CTF into its own category

### DIFF
--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/B/0/7/3ccb42/ctf-bungletunnel-lgi-a1_[073ccb42].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/B/0/7/3ccb42/ctf-bungletunnel-lgi-a1_[073ccb42].yml
@@ -44,7 +44,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "Tunnel"
 playerCount: "Unknown"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/B/b/5/e3f211/ctf-bungletwistedjump-lgi_[b5e3f211].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/B/b/5/e3f211/ctf-bungletwistedjump-lgi_[b5e3f211].yml
@@ -44,7 +44,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "TwistedJump"
 playerCount: "12"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/C/5/9/ca518e/ctf-cagematch_lgi_[59ca518e].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/C/5/9/ca518e/ctf-cagematch_lgi_[59ca518e].yml
@@ -50,7 +50,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "CTF-CageMatch_LGI"
 playerCount: "2"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/F/a/5/e4938f/ctf-fawdownunder-lgi_[a5e4938f].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/F/a/5/e4938f/ctf-fawdownunder-lgi_[a5e4938f].yml
@@ -44,7 +44,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "(=Faw=)DownUnder"
 playerCount: "10"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/2/6/7a2fcb/ctf-lgiwp1thornsv3_[267a2fcb].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/2/6/7a2fcb/ctf-lgiwp1thornsv3_[267a2fcb].yml
@@ -45,7 +45,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "(LGIwp1) ThornsV3"
 playerCount: "4-16"
 themes: {}

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/2/b/a6d8e8/ctf-lgiwp2-1on1-vpfragwhore_[2ba6d8e8].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/2/b/a6d8e8/ctf-lgiwp2-1on1-vpfragwhore_[2ba6d8e8].yml
@@ -56,7 +56,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "(LGIwp2)-1on1-(Vp)FragWhoreArena"
 playerCount: "Unknown"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/3/5/03a69f/ctf-lgiwp1-ao-barnburner2k4_[3503a69f].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/3/5/03a69f/ctf-lgiwp1-ao-barnburner2k4_[3503a69f].yml
@@ -49,7 +49,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "(LGIwp1) -)AO(-BarnBurner2K4"
 playerCount: "2-12"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/3/f/109e2e/ctf-lgi-crater_[3f109e2e].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/3/f/109e2e/ctf-lgi-crater_[3f109e2e].yml
@@ -45,7 +45,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "CTF-LGI-Crater"
 playerCount: "4"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/4/c/d4ee3b/ctf-lgiwp1thornsv2_[4cd4ee3b].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/4/c/d4ee3b/ctf-lgiwp1thornsv2_[4cd4ee3b].yml
@@ -43,7 +43,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "(LGIwp1) ThornsV2"
 playerCount: "4-12"
 themes: {}

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/5/f/e96645/ctf-lgiwp1thornsv4_[5fe96645].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/5/f/e96645/ctf-lgiwp1thornsv4_[5fe96645].yml
@@ -41,7 +41,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "(LGIwp1) ThornsV4"
 playerCount: "4-14"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/6/2/166bfb/ctf-lgiwp1thornsv2_[62166bfb].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/6/2/166bfb/ctf-lgiwp1thornsv2_[62166bfb].yml
@@ -47,7 +47,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "(LGIwp1) ThornsV2"
 playerCount: "4-12"
 themes: {}

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/6/d/23102f/ctf-lgiwp1thornsv3_[6d23102f].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/6/d/23102f/ctf-lgiwp1thornsv3_[6d23102f].yml
@@ -41,7 +41,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "(LGIwp1) ThornsV3"
 playerCount: "4-16"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/7/8/5d9cbd/ctf-lgiwp2thornsv5_[785d9cbd].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/7/8/5d9cbd/ctf-lgiwp2thornsv5_[785d9cbd].yml
@@ -59,7 +59,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "(LGIwp2) ThornsV5"
 playerCount: "2-16"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/7/9/41951b/ctf-lgithegirders_[7941951b].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/7/9/41951b/ctf-lgithegirders_[7941951b].yml
@@ -45,7 +45,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "LGI - The Girders"
 playerCount: "12"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/8/9/6b9540/ctf-lgiwp2mcs-underground2k5_[896b9540].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/8/9/6b9540/ctf-lgiwp2mcs-underground2k5_[896b9540].yml
@@ -51,7 +51,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "(LGIwp2) MCS UnderGround 2K5"
 playerCount: "4-18"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/8/b/0bb1c6/ctf-lgi-smok3tek_ii_[8b0bb1c6].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/8/b/0bb1c6/ctf-lgi-smok3tek_ii_[8b0bb1c6].yml
@@ -45,7 +45,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "CTF-Smok3TeK II"
 playerCount: "10-14"
 themes: {}

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/a/d/8b8879/ctf-lgi-eliminated_[ad8b8879].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/a/d/8b8879/ctf-lgi-eliminated_[ad8b8879].yml
@@ -41,7 +41,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "(LGI) Eliminated"
 playerCount: "12"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/a/e/2263eb/ctf-lgiwp1-ao-barnburner2k4_[ae2263eb].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/a/e/2263eb/ctf-lgiwp1-ao-barnburner2k4_[ae2263eb].yml
@@ -45,7 +45,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "(LGIwp1) -)AO(-BarnBurner2K4"
 playerCount: "2-12"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/b/0/e279cb/ctf-lgiwp1bos-egyptian2k4_[b0e279cb].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/b/0/e279cb/ctf-lgiwp1bos-egyptian2k4_[b0e279cb].yml
@@ -47,7 +47,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "(LGIwp1) BoS-Egyptian2K4"
 playerCount: "2-16"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/b/1/2648c5/ctf-lgiwp1bos-egyptian2k4_[b12648c5].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/b/1/2648c5/ctf-lgiwp1bos-egyptian2k4_[b12648c5].yml
@@ -47,7 +47,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "(LGIwp1) BoS-Egyptian2K4"
 playerCount: "2-16"
 themes: {}

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/b/b/8daaa2/ctf-lgiwp1thornsv4_[bb8daaa2].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/b/b/8daaa2/ctf-lgiwp1thornsv4_[bb8daaa2].yml
@@ -45,7 +45,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "(LGIwp1) ThornsV4"
 playerCount: "4-14"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/c/b/39c88c/ctf-lgiwp1romra2k4_[cb39c88c].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/c/b/39c88c/ctf-lgiwp1romra2k4_[cb39c88c].yml
@@ -46,7 +46,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "(LGIwp1) Romra2K4"
 playerCount: "4-12"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/d/1/4c7d17/ctf-lgiwp1elitearena2k4_[d14c7d17].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/d/1/4c7d17/ctf-lgiwp1elitearena2k4_[d14c7d17].yml
@@ -45,7 +45,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "(LGIwp1) Elite Arena2K4"
 playerCount: "2-16"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/d/6/7b9f75/ctf-lgi-london_[d67b9f75].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/d/6/7b9f75/ctf-lgi-london_[d67b9f75].yml
@@ -59,7 +59,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "CTF-LGI-London"
 playerCount: "2"
 themes: {}

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/d/d/2cfb42/ctf-lgiwp2ruins2k5_[dd2cfb42].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/d/d/2cfb42/ctf-lgiwp2ruins2k5_[dd2cfb42].yml
@@ -49,7 +49,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "(LGIwp2)Ruins2K5"
 playerCount: "4-18"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/e/d/b45f9c/ctf-lgiwp1stadium2k4_[edb45f9c].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/e/d/b45f9c/ctf-lgiwp1stadium2k4_[edb45f9c].yml
@@ -45,7 +45,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "(LGIwp1) Stadium2K4"
 playerCount: "2-12"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/f/3/8fbaa7/ctf-lgiwp1stadium2k4_[f38fbaa7].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/f/3/8fbaa7/ctf-lgiwp1stadium2k4_[f38fbaa7].yml
@@ -45,7 +45,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "(LGIwp1) Stadium2K4"
 playerCount: "2-12"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/f/d/522d78/ctf-lgiwp1romra2k4_[fd522d78].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/f/d/522d78/ctf-lgiwp1romra2k4_[fd522d78].yml
@@ -46,7 +46,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "(LGIwp1) Romra2K4"
 playerCount: "4-12"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/L/f/e/e915b6/ctf-lgiwp1elitearena2k4_[fee915b6].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/L/f/e/e915b6/ctf-lgiwp1elitearena2k4_[fee915b6].yml
@@ -41,7 +41,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "(LGIwp1) Elite Arena2K4"
 playerCount: "2-16"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/M/5/c/ddb271/ctf-mcsunderground2k4_lgi_[5cddb271].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/M/5/c/ddb271/ctf-mcsunderground2k4_lgi_[5cddb271].yml
@@ -43,7 +43,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "[MCS]UnderGround2K3_LGI"
 playerCount: "4-16"
 themes:

--- a/content/Unreal Tournament/MapPacks/L/3/2/8a187f/lgz-ictf-mappack-2on2-2005_[328a187f].yml
+++ b/content/Unreal Tournament/MapPacks/L/3/2/8a187f/lgz-ictf-mappack-2on2-2005_[328a187f].yml
@@ -111,7 +111,7 @@ maps:
 - name: "CTF-ExtortionCB2"
   title: "CTF-Extortion_CE - CB Version -"
   author: "Edited by Rambo ASS - Surgery by: zOil"
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 themes:
   Nali Temple: 0.1
   Tech: 0.3

--- a/content/Unreal Tournament/MapPacks/L/4/f/3b6eba/lgz-ictf-mappack-5on5-2005_[4f3b6eba].yml
+++ b/content/Unreal Tournament/MapPacks/L/4/f/3b6eba/lgz-ictf-mappack-5on5-2005_[4f3b6eba].yml
@@ -207,7 +207,7 @@ maps:
 - name: "CTF-SiberiaN23"
   title: "CTF-SiberiaN23"
   author: "Daniel \"KaMi\" Díaz"
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 themes:
   Tech: 0.2
   Industrial: 0.5

--- a/content/Unreal Tournament/Maps/Capture The Flag/A/4/1/be96dc/ctf-acidpipemok-lgi-v1_[41be96dc].yml
+++ b/content/Unreal Tournament/Maps/Capture The Flag/A/4/1/be96dc/ctf-acidpipemok-lgi-v1_[41be96dc].yml
@@ -46,7 +46,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "CTF-AcidPipe-MOK-LGI-V1"
 playerCount: "10 -14"
 themes:

--- a/content/Unreal Tournament/Maps/Capture The Flag/M/5/9/0e013d/ctf-moonrunlgi_[590e013d].yml
+++ b/content/Unreal Tournament/Maps/Capture The Flag/M/5/9/0e013d/ctf-moonrunlgi_[590e013d].yml
@@ -45,7 +45,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "((Moon Run )) LGI Edition"
 playerCount: "4-12"
 themes:

--- a/content/Unreal Tournament/Maps/Capture The Flag/M/f/7/90d554/ctf-moonrunlgi_[f790d554].yml
+++ b/content/Unreal Tournament/Maps/Capture The Flag/M/f/7/90d554/ctf-moonrunlgi_[f790d554].yml
@@ -42,7 +42,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Capture The Flag"
+gametype: "LowGrav InstaGib CTF"
 title: "((Moon Run )) LGI Edition"
 playerCount: "4-12"
 themes:


### PR DESCRIPTION
These maps differentiate from regular CTF in that... they lack weapons (ergo, made for Instagib CTF), and they're specifically made for Instagib + Low Gravity.