### PR TITLE
Ut2004fix

### DIFF
--- a/content/Unknown/Mutators/M/a/6/7a6aa1/mutator-toolbox_[a67a6aa1].yml
+++ b/content/Unknown/Mutators/M/a/6/7a6aa1/mutator-toolbox_[a67a6aa1].yml
@@ -1,7 +1,7 @@
 --- !<MUTATOR>
 contentType: "MUTATOR"
 firstIndex: "2022-05-21 20:46"
-game: "Unknown"
+game: "Unreal Tournament"
 name: "Mutator Toolbox"
 author: "ammo pickups"
 description: " Many Options to alter UT"

--- a/content/Unreal Tournament 2004/Maps/Unknown/D/9/8/39486b/duel-desertgrave_[9839486b].yml
+++ b/content/Unreal Tournament 2004/Maps/Unknown/D/9/8/39486b/duel-desertgrave_[9839486b].yml
@@ -172,7 +172,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Unknown"
+gametype: "ChaosUT"
 title: "DesertGrave"
 playerCount: "2-4"
 themes: {}

--- a/content/Unreal Tournament 2004/Maps/Unknown/N/d/b/f3002b/nyctest1920mapv11_[dbf3002b].yml
+++ b/content/Unreal Tournament 2004/Maps/Unknown/N/d/b/f3002b/nyctest1920mapv11_[dbf3002b].yml
@@ -52,7 +52,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Unknown"
+gametype: "Tests and Demos"
 title: "none"
 playerCount: "Unknown"
 themes:

--- a/content/Unreal Tournament 2004/Maps/Unknown/S/b/d/c2b319/superadrenaline_[bdc2b319].yml
+++ b/content/Unreal Tournament 2004/Maps/Unknown/S/b/d/c2b319/superadrenaline_[bdc2b319].yml
@@ -45,7 +45,7 @@ downloads:
   repack: false
   state: "OK"
 deleted: false
-gametype: "Unknown"
+gametype: "Tests and Demos"
 title: "SuperAdrenaline"
 playerCount: "Unknown"
 themes:


### PR DESCRIPTION
* Mutator Toolbox properly assigned to UT.
* Duel_DesertGrave (UT2004) marked as a Chaos UT2E map.
* NYCTest1920Map and SuperAdrenaline (UT2004) marked as Test maps.