### PR TITLE
Remove duplicate Azure mirrors

### DIFF
--- a/content/Unreal 2/Mutators/K/b/3/e710cc/kick-automaticaly-the-team-killers_[b3e710cc].yml
+++ b/content/Unreal 2/Mutators/K/b/3/e710cc/kick-automaticaly-the-team-killers_[b3e710cc].yml
@@ -24,14 +24,6 @@ downloads:
   main: true
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Mutators/K/b/3/e710cc/AntiTeamKiller.zip"
-  main: false
-  repack: false
-  state: "OK"
-- url: "https://unrealarchivesgp.blob.core.windows.net/files/Unreal%20Tournament%202004/Mutators/K/b/3/e710cc/AntiTeamKiller.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%202/Mutators/K/b/3/e710cc/AntiTeamKiller.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Alien Swarm/B/5/c/b88ceb/ao-bugplanet_[5cb88ceb].yml
+++ b/content/Unreal Tournament 2004/Maps/Alien Swarm/B/5/c/b88ceb/ao-bugplanet_[5cb88ceb].yml
@@ -54,10 +54,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Unknown/A/5/c/b88ceb/ao-bugplanet.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Alien%20Swarm/B/5/c/b88ceb/ao-bugplanet.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Alien Swarm/C/0/e/452679/ao-cleanup2_[0e452679].yml
+++ b/content/Unreal Tournament 2004/Maps/Alien Swarm/C/0/e/452679/ao-cleanup2_[0e452679].yml
@@ -62,10 +62,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Unknown/A/0/e/452679/ao-cleanup2.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Alien%20Swarm/C/0/e/452679/ao-cleanup2.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Alien Swarm/C/9/d/613675/ao-cleanup_[9d613675].yml
+++ b/content/Unreal Tournament 2004/Maps/Alien Swarm/C/9/d/613675/ao-cleanup_[9d613675].yml
@@ -58,10 +58,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Unknown/A/9/d/613675/ao-cleanup.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Alien%20Swarm/C/9/d/613675/ao-cleanup.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Alien Swarm/D/b/b/f97ac7/ao-depot_[bbf97ac7].yml
+++ b/content/Unreal Tournament 2004/Maps/Alien Swarm/D/b/b/f97ac7/ao-depot_[bbf97ac7].yml
@@ -66,10 +66,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Single%20Player/A/b/b/f97ac7/ao-depotfinal1.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Alien%20Swarm/D/b/b/f97ac7/ao-depotfinal1.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/CarBall/W/5/a/b59991/cb-war_[5ab59991].yml
+++ b/content/Unreal Tournament 2004/Maps/CarBall/W/5/a/b59991/cb-war_[5ab59991].yml
@@ -43,10 +43,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Unknown/C/5/a/b59991/CB-War.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/CarBall/W/5/a/b59991/CB-War.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/ChaosUT/D/9/8/39486b/duel-desertgrave_[9839486b].yml
+++ b/content/Unreal Tournament 2004/Maps/ChaosUT/D/9/8/39486b/duel-desertgrave_[9839486b].yml
@@ -167,10 +167,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Unknown/D/9/8/39486b/chaosut2pr351patch.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/ChaosUT/D/9/8/39486b/chaosut2pr351patch.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Classic Domination/0/0/0/7dff88/cdom-1on1-loststation_[007dff88].yml
+++ b/content/Unreal Tournament 2004/Maps/Classic Domination/0/0/0/7dff88/cdom-1on1-loststation_[007dff88].yml
@@ -52,10 +52,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Unknown/C/0/0/7dff88/cdom-1on1-loststation.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Classic%20Domination/0/0/0/7dff88/cdom-1on1-loststation.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Classic Domination/0/7/4/a4482f/cdom-1on1-loststation_[74a4482f].yml
+++ b/content/Unreal Tournament 2004/Maps/Classic Domination/0/7/4/a4482f/cdom-1on1-loststation_[74a4482f].yml
@@ -43,10 +43,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Unknown/C/7/4/a4482f/cdom-1on1-loststation.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Classic%20Domination/0/7/4/a4482f/cdom-1on1-loststation.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Classic Domination/A/7/7/af7f09/cdom-ar-loststation_[77af7f09].yml
+++ b/content/Unreal Tournament 2004/Maps/Classic Domination/A/7/7/af7f09/cdom-ar-loststation_[77af7f09].yml
@@ -38,10 +38,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Unknown/C/7/7/af7f09/cdom-ar-loststation.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Classic%20Domination/A/7/7/af7f09/cdom-ar-loststation.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Classic Domination/A/b/c/c1b7a5/cdom-ar-loststation_[bcc1b7a5].yml
+++ b/content/Unreal Tournament 2004/Maps/Classic Domination/A/b/c/c1b7a5/cdom-ar-loststation_[bcc1b7a5].yml
@@ -34,10 +34,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Unknown/C/b/c/c1b7a5/cDOM-AR-LostStation.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Classic%20Domination/A/b/c/c1b7a5/cDOM-AR-LostStation.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Fraghouse Invasion/N/2/8/1ea20b/fhinv-dustydune_[281ea20b].yml
+++ b/content/Unreal Tournament 2004/Maps/Fraghouse Invasion/N/2/8/1ea20b/fhinv-dustydune_[281ea20b].yml
@@ -44,10 +44,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Unknown/F/2/8/1ea20b/fhinvasion_patch_v11.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Fraghouse%20Invasion/N/2/8/1ea20b/fhinvasion_patch_v11.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Fraghouse Invasion/N/a/3/e2ef66/fhinv-reestablishment_[a3e2ef66].yml
+++ b/content/Unreal Tournament 2004/Maps/Fraghouse Invasion/N/a/3/e2ef66/fhinv-reestablishment_[a3e2ef66].yml
@@ -39,10 +39,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Unknown/F/a/3/e2ef66/2k4_fhinv-reestablishment.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Fraghouse%20Invasion/N/a/3/e2ef66/2k4_fhinv-reestablishment.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/0/5/bfb0c9/dm-invasion-roommadebyratchet_[05bfb0c9].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/0/5/bfb0c9/dm-invasion-roommadebyratchet_[05bfb0c9].yml
@@ -37,10 +37,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/I/0/5/bfb0c9/DM-Invasion-Room%5BMadeByRatchet%5D.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/0/5/bfb0c9/DM-Invasion-Room%5BMadeByRatchet%5D.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/0/8/1f8423/dm-wil-the-mini-inv_[081f8423].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/0/8/1f8423/dm-wil-the-mini-inv_[081f8423].yml
@@ -32,10 +32,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/W/0/8/1f8423/dm-(wil-the-mini-invmap.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/0/8/1f8423/dm-(wil-the-mini-invmap.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/0/9/0bf78c/dm-invthunderbox_[090bf78c].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/0/9/0bf78c/dm-invthunderbox_[090bf78c].yml
@@ -44,10 +44,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/I/0/9/0bf78c/dminvthunderbox.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/0/9/0bf78c/dminvthunderbox.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/1/4/f6ebea/dm-retro-1up-inv_[14f6ebea].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/1/4/f6ebea/dm-retro-1up-inv_[14f6ebea].yml
@@ -33,10 +33,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/R/1/4/f6ebea/DM-Retro-1UP-INV.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/1/4/f6ebea/DM-Retro-1UP-INV.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/1/9/6436aa/dm-inv-alienlockdown_[196436aa].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/1/9/6436aa/dm-inv-alienlockdown_[196436aa].yml
@@ -36,10 +36,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/I/1/9/6436aa/DM-INV-AlienLockdown.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/1/9/6436aa/DM-INV-AlienLockdown.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/3/d/13a2d5/dm-da-giant-gas-bag-inv_[3d13a2d5].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/3/d/13a2d5/dm-da-giant-gas-bag-inv_[3d13a2d5].yml
@@ -32,10 +32,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/D/3/d/13a2d5/dm-da-giant-gas-bag-inv.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/3/d/13a2d5/dm-da-giant-gas-bag-inv.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/4/0/536be1/dm-inv-omfgsokool_[40536be1].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/4/0/536be1/dm-inv-omfgsokool_[40536be1].yml
@@ -36,10 +36,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/I/4/0/536be1/DM-INV-OMFGSOKOOL.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/4/0/536be1/DM-INV-OMFGSOKOOL.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/4/1/336999/dm-gu-inv-primeval_[41336999].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/4/1/336999/dm-gu-inv-primeval_[41336999].yml
@@ -47,10 +47,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/G/4/1/336999/dm-%5Bgu%5D-inv-primevil.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/4/1/336999/dm-%5Bgu%5D-inv-primevil.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/6/4/359b4c/dm-gu-inv-spaced_[64359b4c].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/6/4/359b4c/dm-gu-inv-spaced_[64359b4c].yml
@@ -36,10 +36,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/G/6/4/359b4c/dm-gu-inv-spaced.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/6/4/359b4c/dm-gu-inv-spaced.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/6/8/b24cf0/dm-odc_whenworldscollide-inv_[68b24cf0].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/6/8/b24cf0/dm-odc_whenworldscollide-inv_[68b24cf0].yml
@@ -40,10 +40,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/O/6/8/b24cf0/DM-ODC_WhenWorldsCollide-V.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/6/8/b24cf0/DM-ODC_WhenWorldsCollide-V.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/6/a/1d9907/dm-deathbowlfortress-inv_[6a1d9907].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/6/a/1d9907/dm-deathbowlfortress-inv_[6a1d9907].yml
@@ -44,10 +44,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/D/6/a/1d9907/dmdeathbowlfortress.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/6/a/1d9907/dmdeathbowlfortress.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/6/b/51065f/dm-xg-inv-indoor-soccer_[6b51065f].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/6/b/51065f/dm-xg-inv-indoor-soccer_[6b51065f].yml
@@ -39,10 +39,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/X/6/b/51065f/dm-xg-inv-indoor-soccer.ut2.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/6/b/51065f/dm-xg-inv-indoor-soccer.ut2.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/7/4/deb66d/dm-ironic_inv_b1_[74deb66d].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/7/4/deb66d/dm-ironic_inv_b1_[74deb66d].yml
@@ -31,10 +31,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/I/7/4/deb66d/DM-Ironic_INV_B1.rar"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/7/4/deb66d/DM-Ironic_INV_B1.rar"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/7/e/e78e7a/dm-xg-inv-indoor-pool_[7ee78e7a].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/7/e/e78e7a/dm-xg-inv-indoor-pool_[7ee78e7a].yml
@@ -39,10 +39,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/X/7/e/e78e7a/dm-xg-inv-indoorpool.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/7/e/e78e7a/dm-xg-inv-indoorpool.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/8/5/68e705/dm-xg-inv-lostcity_[8568e705].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/8/5/68e705/dm-xg-inv-lostcity_[8568e705].yml
@@ -36,10 +36,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/X/8/5/68e705/dm-xg-inv-lostcity.ut2.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/8/5/68e705/dm-xg-inv-lostcity.ut2.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/a/4/db61bf/dm-gu-inv-spaced-v2_[a4db61bf].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/a/4/db61bf/dm-gu-inv-spaced-v2_[a4db61bf].yml
@@ -36,10 +36,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/G/a/4/db61bf/DM-%5BGU%5D-INV-Spaced-v2.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/a/4/db61bf/DM-%5BGU%5D-INV-Spaced-v2.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/a/9/b2adb0/dm-sealed-inv_[a9b2adb0].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/a/9/b2adb0/dm-sealed-inv_[a9b2adb0].yml
@@ -35,10 +35,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/S/a/9/b2adb0/DM-Sealed-INV.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/a/9/b2adb0/DM-Sealed-INV.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/a/c/66d2fe/dm-inv-sandstorm_[ac66d2fe].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/a/c/66d2fe/dm-inv-sandstorm_[ac66d2fe].yml
@@ -40,10 +40,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/I/a/c/66d2fe/dm-inv-sandstorm.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/a/c/66d2fe/dm-inv-sandstorm.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/a/f/6f0048/dm-retribution-inv_[af6f0048].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/a/f/6f0048/dm-retribution-inv_[af6f0048].yml
@@ -53,10 +53,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/R/a/f/6f0048/dm-retribution-invasion.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/a/f/6f0048/dm-retribution-invasion.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/b/8/2abf3b/dm-inv-testingoutbreakv1_[b82abf3b].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/b/8/2abf3b/dm-inv-testingoutbreakv1_[b82abf3b].yml
@@ -42,10 +42,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/I/b/8/2abf3b/DM-INV-TestingOutbreakV1.rar"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/b/8/2abf3b/DM-INV-TestingOutbreakV1.rar"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/d/0/dbbfdd/dm-xg-inv-safe-haven_[d0dbbfdd].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/d/0/dbbfdd/dm-xg-inv-safe-haven_[d0dbbfdd].yml
@@ -39,10 +39,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/X/d/0/dbbfdd/dm-xg-inv-safe-haven.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/d/0/dbbfdd/dm-xg-inv-safe-haven.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/e/0/ce950d/dm-deathbowlfortress-inv_[e0ce950d].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/e/0/ce950d/dm-deathbowlfortress-inv_[e0ce950d].yml
@@ -40,10 +40,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/D/e/0/ce950d/dm-deathbowlfortress.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/e/0/ce950d/dm-deathbowlfortress.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/e/d/b55125/dm-ramenlandv3-inv1_[edb55125].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/e/d/b55125/dm-ramenlandv3-inv1_[edb55125].yml
@@ -39,10 +39,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/R/e/d/b55125/DM-RamenlandV3-Inv1.rar"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/e/d/b55125/DM-RamenlandV3-Inv1.rar"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Invasion/D/f/b/db60c2/dm-gu-inv-circleofpain_[fbdb60c2].yml
+++ b/content/Unreal Tournament 2004/Maps/Invasion/D/f/b/db60c2/dm-gu-inv-circleofpain_[fbdb60c2].yml
@@ -46,10 +46,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/DeathMatch/G/f/b/db60c2/dm-%5Bgu%5D-inv-circleofpain%5D%5B.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Invasion/D/f/b/db60c2/dm-%5Bgu%5D-inv-circleofpain%5D%5B.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/0/7/3ccb42/ctf-bungletunnel-lgi-a1_[073ccb42].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/0/7/3ccb42/ctf-bungletunnel-lgi-a1_[073ccb42].yml
@@ -39,10 +39,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/B/0/7/3ccb42/ctf-bungletunnel-lgi-a1.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/0/7/3ccb42/ctf-bungletunnel-lgi-a1.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/2/6/7a2fcb/ctf-lgiwp1thornsv3_[267a2fcb].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/2/6/7a2fcb/ctf-lgiwp1thornsv3_[267a2fcb].yml
@@ -40,10 +40,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/2/6/7a2fcb/ctf-(lgiwp1)thornsv3.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/2/6/7a2fcb/ctf-(lgiwp1)thornsv3.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/2/b/a6d8e8/ctf-lgiwp2-1on1-vpfragwhore_[2ba6d8e8].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/2/b/a6d8e8/ctf-lgiwp2-1on1-vpfragwhore_[2ba6d8e8].yml
@@ -51,10 +51,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/2/b/a6d8e8/ctf-(lgiwp2)-1on1-(vp)fragwhore.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/2/b/a6d8e8/ctf-(lgiwp2)-1on1-(vp)fragwhore.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/3/5/03a69f/ctf-lgiwp1-ao-barnburner2k4_[3503a69f].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/3/5/03a69f/ctf-lgiwp1-ao-barnburner2k4_[3503a69f].yml
@@ -44,10 +44,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/3/5/03a69f/ctf-(lgiwp1)-)ao(-barnburner2k4.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/3/5/03a69f/ctf-(lgiwp1)-)ao(-barnburner2k4.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/3/f/109e2e/ctf-lgi-crater_[3f109e2e].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/3/f/109e2e/ctf-lgi-crater_[3f109e2e].yml
@@ -40,10 +40,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/3/f/109e2e/CTF-LGI-Crater.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/3/f/109e2e/CTF-LGI-Crater.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/4/c/d4ee3b/ctf-lgiwp1thornsv2_[4cd4ee3b].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/4/c/d4ee3b/ctf-lgiwp1thornsv2_[4cd4ee3b].yml
@@ -38,10 +38,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/4/c/d4ee3b/ctf-(lgiwp1)thornsv2.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/4/c/d4ee3b/ctf-(lgiwp1)thornsv2.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/5/9/ca518e/ctf-cagematch_lgi_[59ca518e].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/5/9/ca518e/ctf-cagematch_lgi_[59ca518e].yml
@@ -45,10 +45,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/C/5/9/ca518e/ctf-cagematch_lgi.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/5/9/ca518e/ctf-cagematch_lgi.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/5/c/ddb271/ctf-mcsunderground2k4_lgi_[5cddb271].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/5/c/ddb271/ctf-mcsunderground2k4_lgi_[5cddb271].yml
@@ -38,10 +38,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/M/5/c/ddb271/ctf-(mcs)underground2k4_lgi.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/5/c/ddb271/ctf-(mcs)underground2k4_lgi.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/5/f/e96645/ctf-lgiwp1thornsv4_[5fe96645].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/5/f/e96645/ctf-lgiwp1thornsv4_[5fe96645].yml
@@ -36,10 +36,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/5/f/e96645/ctf-(lgiwp1)thornsv4.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/5/f/e96645/ctf-(lgiwp1)thornsv4.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/6/2/166bfb/ctf-lgiwp1thornsv2_[62166bfb].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/6/2/166bfb/ctf-lgiwp1thornsv2_[62166bfb].yml
@@ -42,10 +42,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/6/2/166bfb/ctf-(lgiwp1)thornsv2.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/6/2/166bfb/ctf-(lgiwp1)thornsv2.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/6/d/23102f/ctf-lgiwp1thornsv3_[6d23102f].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/6/d/23102f/ctf-lgiwp1thornsv3_[6d23102f].yml
@@ -36,10 +36,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/6/d/23102f/ctf-(lgiwp1)thornsv3.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/6/d/23102f/ctf-(lgiwp1)thornsv3.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/7/8/5d9cbd/ctf-lgiwp2thornsv5_[785d9cbd].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/7/8/5d9cbd/ctf-lgiwp2thornsv5_[785d9cbd].yml
@@ -54,10 +54,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/7/8/5d9cbd/ctf-(lgiwp2)thornsv5.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/7/8/5d9cbd/ctf-(lgiwp2)thornsv5.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/7/9/41951b/ctf-lgithegirders_[7941951b].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/7/9/41951b/ctf-lgithegirders_[7941951b].yml
@@ -40,10 +40,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/7/9/41951b/ctflgithegirders.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/7/9/41951b/ctflgithegirders.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/8/9/6b9540/ctf-lgiwp2mcs-underground2k5_[896b9540].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/8/9/6b9540/ctf-lgiwp2mcs-underground2k5_[896b9540].yml
@@ -46,10 +46,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/8/9/6b9540/ctf-(lgiwp2)mcs-underground2k5.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/8/9/6b9540/ctf-(lgiwp2)mcs-underground2k5.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/8/b/0bb1c6/ctf-lgi-smok3tek_ii_[8b0bb1c6].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/8/b/0bb1c6/ctf-lgi-smok3tek_ii_[8b0bb1c6].yml
@@ -40,10 +40,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/8/b/0bb1c6/ctf-(lgi)-smok3tek_ii.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/8/b/0bb1c6/ctf-(lgi)-smok3tek_ii.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/a/5/e4938f/ctf-fawdownunder-lgi_[a5e4938f].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/a/5/e4938f/ctf-fawdownunder-lgi_[a5e4938f].yml
@@ -39,10 +39,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/F/a/5/e4938f/ctf-(=faw=)downunderlgi.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/a/5/e4938f/ctf-(=faw=)downunderlgi.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/a/d/8b8879/ctf-lgi-eliminated_[ad8b8879].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/a/d/8b8879/ctf-lgi-eliminated_[ad8b8879].yml
@@ -36,10 +36,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/a/d/8b8879/ctf-eliminated.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/a/d/8b8879/ctf-eliminated.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/a/e/2263eb/ctf-lgiwp1-ao-barnburner2k4_[ae2263eb].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/a/e/2263eb/ctf-lgiwp1-ao-barnburner2k4_[ae2263eb].yml
@@ -40,10 +40,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/a/e/2263eb/ctf-(lgiwp1)-)ao(-barnburner2k4.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/a/e/2263eb/ctf-(lgiwp1)-)ao(-barnburner2k4.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/b/0/e279cb/ctf-lgiwp1bos-egyptian2k4_[b0e279cb].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/b/0/e279cb/ctf-lgiwp1bos-egyptian2k4_[b0e279cb].yml
@@ -42,10 +42,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/b/0/e279cb/ctf-(lgiwp1)bos-egyptian2k4.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/b/0/e279cb/ctf-(lgiwp1)bos-egyptian2k4.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/b/1/2648c5/ctf-lgiwp1bos-egyptian2k4_[b12648c5].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/b/1/2648c5/ctf-lgiwp1bos-egyptian2k4_[b12648c5].yml
@@ -42,10 +42,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/b/1/2648c5/ctf-(lgiwp1)bos-egyptian2k4.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/b/1/2648c5/ctf-(lgiwp1)bos-egyptian2k4.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/b/5/e3f211/ctf-bungletwistedjump-lgi_[b5e3f211].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/b/5/e3f211/ctf-bungletwistedjump-lgi_[b5e3f211].yml
@@ -39,10 +39,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/B/b/5/e3f211/ctf-bungletwistedjump-lgi.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/b/5/e3f211/ctf-bungletwistedjump-lgi.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/b/b/8daaa2/ctf-lgiwp1thornsv4_[bb8daaa2].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/b/b/8daaa2/ctf-lgiwp1thornsv4_[bb8daaa2].yml
@@ -40,10 +40,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/b/b/8daaa2/ctf-(lgiwp1)thornsv4.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/b/b/8daaa2/ctf-(lgiwp1)thornsv4.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/c/b/39c88c/ctf-lgiwp1romra2k4_[cb39c88c].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/c/b/39c88c/ctf-lgiwp1romra2k4_[cb39c88c].yml
@@ -41,10 +41,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/c/b/39c88c/ctf-(lgiwp1)romra2k4.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/c/b/39c88c/ctf-(lgiwp1)romra2k4.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/d/1/4c7d17/ctf-lgiwp1elitearena2k4_[d14c7d17].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/d/1/4c7d17/ctf-lgiwp1elitearena2k4_[d14c7d17].yml
@@ -40,10 +40,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/d/1/4c7d17/ctf-(lgiwp1)elitearena2k4.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/d/1/4c7d17/ctf-(lgiwp1)elitearena2k4.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/d/6/7b9f75/ctf-lgi-london_[d67b9f75].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/d/6/7b9f75/ctf-lgi-london_[d67b9f75].yml
@@ -54,10 +54,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/d/6/7b9f75/CTF-LGI-London.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/d/6/7b9f75/CTF-LGI-London.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/d/d/2cfb42/ctf-lgiwp2ruins2k5_[dd2cfb42].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/d/d/2cfb42/ctf-lgiwp2ruins2k5_[dd2cfb42].yml
@@ -44,10 +44,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/d/d/2cfb42/ctf-(lgiwp2)ruins2k5.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/d/d/2cfb42/ctf-(lgiwp2)ruins2k5.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/e/d/b45f9c/ctf-lgiwp1stadium2k4_[edb45f9c].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/e/d/b45f9c/ctf-lgiwp1stadium2k4_[edb45f9c].yml
@@ -40,10 +40,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/e/d/b45f9c/ctf-(lgiwp1)stadium2k4.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/e/d/b45f9c/ctf-(lgiwp1)stadium2k4.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/f/3/8fbaa7/ctf-lgiwp1stadium2k4_[f38fbaa7].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/f/3/8fbaa7/ctf-lgiwp1stadium2k4_[f38fbaa7].yml
@@ -40,10 +40,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/f/3/8fbaa7/ctf-(lgiwp1)stadium2k4.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/f/3/8fbaa7/ctf-(lgiwp1)stadium2k4.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/f/d/522d78/ctf-lgiwp1romra2k4_[fd522d78].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/f/d/522d78/ctf-lgiwp1romra2k4_[fd522d78].yml
@@ -41,10 +41,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/f/d/522d78/ctf-(lgiwp1)romra2k4.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/f/d/522d78/ctf-(lgiwp1)romra2k4.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/f/e/e915b6/ctf-lgiwp1elitearena2k4_[fee915b6].yml
+++ b/content/Unreal Tournament 2004/Maps/LowGrav InstaGib CTF/C/f/e/e915b6/ctf-lgiwp1elitearena2k4_[fee915b6].yml
@@ -36,10 +36,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/L/f/e/e915b6/ctf-(lgiwp1)elitearena2k4.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/LowGrav%20InstaGib%20CTF/C/f/e/e915b6/ctf-(lgiwp1)elitearena2k4.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Movies, Machinimas and Entries/N/a/7/ea7c2d/nvidialogo_[a7ea7c2d].yml
+++ b/content/Unreal Tournament 2004/Maps/Movies, Machinimas and Entries/N/a/7/ea7c2d/nvidialogo_[a7ea7c2d].yml
@@ -33,10 +33,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Unknown/N/a/7/ea7c2d/NvidiaLogo.ut2"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Movies,%20Machinimas%20and%20Entries/N/a/7/ea7c2d/NvidiaLogo.ut2"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Movies, Machinimas and Entries/S/6/5/135fd1/mov-stargate_[65135fd1].yml
+++ b/content/Unreal Tournament 2004/Maps/Movies, Machinimas and Entries/S/6/5/135fd1/mov-stargate_[65135fd1].yml
@@ -52,10 +52,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Unknown/M/6/5/135fd1/mov-stargate.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Movies,%20Machinimas%20and%20Entries/S/6/5/135fd1/mov-stargate.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Movies, Machinimas and Entries/U/4/3/e98d6c/uteroslogo_[43e98d6c].yml
+++ b/content/Unreal Tournament 2004/Maps/Movies, Machinimas and Entries/U/4/3/e98d6c/uteroslogo_[43e98d6c].yml
@@ -25,10 +25,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Unknown/U/4/3/e98d6c/NvidiaLogo.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Movies,%20Machinimas%20and%20Entries/U/4/3/e98d6c/NvidiaLogo.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Tests and Demos/N/d/b/f3002b/nyctest1920mapv11_[dbf3002b].yml
+++ b/content/Unreal Tournament 2004/Maps/Tests and Demos/N/d/b/f3002b/nyctest1920mapv11_[dbf3002b].yml
@@ -47,10 +47,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Unknown/N/d/b/f3002b/desp2_nyc1920s.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Tests%20and%20Demos/N/d/b/f3002b/desp2_nyc1920s.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Maps/Tests and Demos/S/b/d/c2b319/superadrenaline_[bdc2b319].yml
+++ b/content/Unreal Tournament 2004/Maps/Tests and Demos/S/b/d/c2b319/superadrenaline_[bdc2b319].yml
@@ -40,10 +40,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Unknown/S/b/d/c2b319/re-archive_superadrenaline.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Maps/Tests%20and%20Demos/S/b/d/c2b319/re-archive_superadrenaline.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Voices/C/6/b/2fb4d1/classic-fps-voice-packs_[6b2fb4d1].yml
+++ b/content/Unreal Tournament 2004/Voices/C/6/b/2fb4d1/classic-fps-voice-packs_[6b2fb4d1].yml
@@ -64,10 +64,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Voices/S/6/b/2fb4d1/UVMiscellaneous.rar"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Voices/C/6/b/2fb4d1/UVMiscellaneous.rar"
   main: false
   repack: false

--- a/content/Unreal Tournament 2004/Voices/T/a/e/8e1793/the-elder-scrolls-v-skyrim-voice-packs_[ae8e1793].yml
+++ b/content/Unreal Tournament 2004/Voices/T/a/e/8e1793/the-elder-scrolls-v-skyrim-voice-packs_[ae8e1793].yml
@@ -107,10 +107,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Voices/S/a/e/8e1793/UVSkyrim.rar"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament%202004/Voices/T/a/e/8e1793/UVSkyrim.rar"
   main: false
   repack: false

--- a/content/Unreal Tournament/MapPacks/A/2/b/18a849/armageddon-maps-v100_[2b18a849].yml
+++ b/content/Unreal Tournament/MapPacks/A/2/b/18a849/armageddon-maps-v100_[2b18a849].yml
@@ -52,10 +52,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal/MapPacks/A/2/b/18a849/ArmageddonMapsV100.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/MapPacks/A/2/b/18a849/ArmageddonMapsV100.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/MapPacks/D/5/b/466f43/dejavu-gryphon-revisited_[5b466f43].yml
+++ b/content/Unreal Tournament/MapPacks/D/5/b/466f43/dejavu-gryphon-revisited_[5b466f43].yml
@@ -281,10 +281,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/MapPacks/U/5/b/466f43/USPmappack.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/MapPacks/D/5/b/466f43/USPmappack.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/DarkMatch/D/0/c/6f775f/tdk-darkzone_[0c6f775f].yml
+++ b/content/Unreal Tournament/Maps/DarkMatch/D/0/c/6f775f/tdk-darkzone_[0c6f775f].yml
@@ -79,10 +79,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/T/0/c/6f775f/tdk-darkzone.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/DarkMatch/D/0/c/6f775f/tdk-darkzone.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/DarkMatch/N/2/d/6f19c0/tdk-nightop_[2d6f19c0].yml
+++ b/content/Unreal Tournament/Maps/DarkMatch/N/2/d/6f19c0/tdk-nightop_[2d6f19c0].yml
@@ -44,10 +44,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/T/2/d/6f19c0/TDK-NightOp.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/DarkMatch/N/2/d/6f19c0/TDK-NightOp.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/DeathMatch/0/a/c/6604c8/4269_dm-allienroom-v_[ac6604c8].yml
+++ b/content/Unreal Tournament/Maps/DeathMatch/0/a/c/6604c8/4269_dm-allienroom-v_[ac6604c8].yml
@@ -25,10 +25,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/0/a/c/6604c8/4269_DM-Allienroom-V.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/DeathMatch/0/a/c/6604c8/4269_DM-Allienroom-V.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/LowGrav InstaGib CTF/C/4/1/be96dc/ctf-acidpipemok-lgi-v1_[41be96dc].yml
+++ b/content/Unreal Tournament/Maps/LowGrav InstaGib CTF/C/4/1/be96dc/ctf-acidpipemok-lgi-v1_[41be96dc].yml
@@ -41,10 +41,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Capture%20The%20Flag/A/4/1/be96dc/ctf-acidpipemok-lgi-v1.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/LowGrav%20InstaGib%20CTF/C/4/1/be96dc/ctf-acidpipemok-lgi-v1.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/LowGrav InstaGib CTF/C/5/9/0e013d/ctf-moonrunlgi_[590e013d].yml
+++ b/content/Unreal Tournament/Maps/LowGrav InstaGib CTF/C/5/9/0e013d/ctf-moonrunlgi_[590e013d].yml
@@ -40,10 +40,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Capture%20The%20Flag/M/5/9/0e013d/CTF-((MoonRun))LGI.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/LowGrav%20InstaGib%20CTF/C/5/9/0e013d/CTF-((MoonRun))LGI.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/LowGrav InstaGib CTF/C/f/7/90d554/ctf-moonrunlgi_[f790d554].yml
+++ b/content/Unreal Tournament/Maps/LowGrav InstaGib CTF/C/f/7/90d554/ctf-moonrunlgi_[f790d554].yml
@@ -37,10 +37,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Capture%20The%20Flag/M/f/7/90d554/ctf-((moonrun))lgi.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/LowGrav%20InstaGib%20CTF/C/f/7/90d554/ctf-((moonrun))lgi.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Monster Match/A/7/c/41f676/mm-ancienttitan_[7c41f676].yml
+++ b/content/Unreal Tournament/Maps/Monster Match/A/7/c/41f676/mm-ancienttitan_[7c41f676].yml
@@ -39,10 +39,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/M/7/c/41f676/MM-AncientTitan.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Monster%20Match/A/7/c/41f676/MM-AncientTitan.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Monster Match/A/b/5/fe0c98/mm-antalius_[b5fe0c98].yml
+++ b/content/Unreal Tournament/Maps/Monster Match/A/b/5/fe0c98/mm-antalius_[b5fe0c98].yml
@@ -54,10 +54,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/M/b/5/fe0c98/MM-Antalius.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Monster%20Match/A/b/5/fe0c98/MM-Antalius.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Monster Match/A/e/5/ebed92/mm-ancientvillage_[e5ebed92].yml
+++ b/content/Unreal Tournament/Maps/Monster Match/A/e/5/ebed92/mm-ancientvillage_[e5ebed92].yml
@@ -44,10 +44,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/M/e/5/ebed92/MM-AncientVillage.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Monster%20Match/A/e/5/ebed92/MM-AncientVillage.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Monster Match/C/5/4/2afbca/mm-cave_[542afbca].yml
+++ b/content/Unreal Tournament/Maps/Monster Match/C/5/4/2afbca/mm-cave_[542afbca].yml
@@ -44,10 +44,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/M/5/4/2afbca/MM-Cave.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Monster%20Match/C/5/4/2afbca/MM-Cave.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Monster Match/D/7/f/4f56bd/mm-duskfalls_[7f4f56bd].yml
+++ b/content/Unreal Tournament/Maps/Monster Match/D/7/f/4f56bd/mm-duskfalls_[7f4f56bd].yml
@@ -44,10 +44,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/M/7/f/4f56bd/MM-DuskFalls.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Monster%20Match/D/7/f/4f56bd/MM-DuskFalls.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Monster Match/G/0/5/a95626/mm-glacena_[05a95626].yml
+++ b/content/Unreal Tournament/Maps/Monster Match/G/0/5/a95626/mm-glacena_[05a95626].yml
@@ -49,10 +49,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/M/0/5/a95626/MM-Glacena.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Monster%20Match/G/0/5/a95626/MM-Glacena.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Monster Match/H/1/c/001180/mm-harobed_[1c001180].yml
+++ b/content/Unreal Tournament/Maps/Monster Match/H/1/c/001180/mm-harobed_[1c001180].yml
@@ -44,10 +44,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/M/1/c/001180/MM-Harobed.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Monster%20Match/H/1/c/001180/MM-Harobed.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Monster Match/K/2/4/d5064a/mm-kosovfalls_[24d5064a].yml
+++ b/content/Unreal Tournament/Maps/Monster Match/K/2/4/d5064a/mm-kosovfalls_[24d5064a].yml
@@ -39,10 +39,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/M/2/4/d5064a/MM-KosovFalls.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Monster%20Match/K/2/4/d5064a/MM-KosovFalls.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Monster Match/N/9/8/372fb7/mm-nalicastle_[98372fb7].yml
+++ b/content/Unreal Tournament/Maps/Monster Match/N/9/8/372fb7/mm-nalicastle_[98372fb7].yml
@@ -44,10 +44,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/M/9/8/372fb7/MM-NaliCastle.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Monster%20Match/N/9/8/372fb7/MM-NaliCastle.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Monster Match/N/e/6/f6261d/mm-nalilord_[e6f6261d].yml
+++ b/content/Unreal Tournament/Maps/Monster Match/N/e/6/f6261d/mm-nalilord_[e6f6261d].yml
@@ -44,10 +44,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/M/e/6/f6261d/MM-NaliLord.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Monster%20Match/N/e/6/f6261d/MM-NaliLord.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Monster Match/R/f/2/5a34df/mm-revenge_[f25a34df].yml
+++ b/content/Unreal Tournament/Maps/Monster Match/R/f/2/5a34df/mm-revenge_[f25a34df].yml
@@ -44,10 +44,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/M/f/2/5a34df/MM-Revenge.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Monster%20Match/R/f/2/5a34df/MM-Revenge.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Monster Match/S/c/3/49cb5e/mm-spirevillage_[c349cb5e].yml
+++ b/content/Unreal Tournament/Maps/Monster Match/S/c/3/49cb5e/mm-spirevillage_[c349cb5e].yml
@@ -44,10 +44,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/M/c/3/49cb5e/MM-SpireVillage.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Monster%20Match/S/c/3/49cb5e/MM-SpireVillage.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Monster Match/S/e/9/b8fba1/mm-spireland_[e9b8fba1].yml
+++ b/content/Unreal Tournament/Maps/Monster Match/S/e/9/b8fba1/mm-spireland_[e9b8fba1].yml
@@ -44,10 +44,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/M/e/9/b8fba1/MM-SpireLand.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Monster%20Match/S/e/9/b8fba1/MM-SpireLand.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Monster Match/V/9/8/95d88f/mm-vandora_[9895d88f].yml
+++ b/content/Unreal Tournament/Maps/Monster Match/V/9/8/95d88f/mm-vandora_[9895d88f].yml
@@ -44,10 +44,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/M/9/8/95d88f/MM-Vandora.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Monster%20Match/V/9/8/95d88f/MM-Vandora.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Monster Match/V/a/d/f67341/mm-valleyfalls_[adf67341].yml
+++ b/content/Unreal Tournament/Maps/Monster Match/V/a/d/f67341/mm-valleyfalls_[adf67341].yml
@@ -44,10 +44,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/M/a/d/f67341/MM-ValleyFalls.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Monster%20Match/V/a/d/f67341/MM-ValleyFalls.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Monster Match/V/b/4/a512ff/mm-velora_[b4a512ff].yml
+++ b/content/Unreal Tournament/Maps/Monster Match/V/b/4/a512ff/mm-velora_[b4a512ff].yml
@@ -44,10 +44,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/M/b/4/a512ff/MM-Velora.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Monster%20Match/V/b/4/a512ff/MM-Velora.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Perfect Dark UT/A/0/d/ea2232/pd-area52_[0dea2232].yml
+++ b/content/Unreal Tournament/Maps/Perfect Dark UT/A/0/d/ea2232/pd-area52_[0dea2232].yml
@@ -43,10 +43,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/P/0/d/ea2232/pd-area52.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Perfect%20Dark%20UT/A/0/d/ea2232/pd-area52.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Perfect Dark UT/C/9/3/710687/pd-carpark_[93710687].yml
+++ b/content/Unreal Tournament/Maps/Perfect Dark UT/C/9/3/710687/pd-carpark_[93710687].yml
@@ -43,10 +43,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/P/9/3/710687/pd-carpark.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Perfect%20Dark%20UT/C/9/3/710687/pd-carpark.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Perfect Dark UT/F/0/6/064c0a/pd-felicity_[06064c0a].yml
+++ b/content/Unreal Tournament/Maps/Perfect Dark UT/F/0/6/064c0a/pd-felicity_[06064c0a].yml
@@ -40,10 +40,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/P/0/6/064c0a/pd-felicity2.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Perfect%20Dark%20UT/F/0/6/064c0a/pd-felicity2.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Perfect Dark UT/F/1/1/6525de/pd-felicity_[116525de].yml
+++ b/content/Unreal Tournament/Maps/Perfect Dark UT/F/1/1/6525de/pd-felicity_[116525de].yml
@@ -43,10 +43,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/P/1/1/6525de/pd-felicity.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Perfect%20Dark%20UT/F/1/1/6525de/pd-felicity.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Perfect Dark UT/F/7/d/974e41/pd-fortress_[7d974e41].yml
+++ b/content/Unreal Tournament/Maps/Perfect Dark UT/F/7/d/974e41/pd-fortress_[7d974e41].yml
@@ -40,10 +40,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/P/7/d/974e41/pd-fortress.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Perfect%20Dark%20UT/F/7/d/974e41/pd-fortress.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Perfect Dark UT/G/c/8/37d283/pd-grid_[c837d283].yml
+++ b/content/Unreal Tournament/Maps/Perfect Dark UT/G/c/8/37d283/pd-grid_[c837d283].yml
@@ -43,10 +43,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/P/c/8/37d283/pd-grid.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Perfect%20Dark%20UT/G/c/8/37d283/pd-grid.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Perfect Dark UT/G/d/7/fab096/pd-g5building_[d7fab096].yml
+++ b/content/Unreal Tournament/Maps/Perfect Dark UT/G/d/7/fab096/pd-g5building_[d7fab096].yml
@@ -43,10 +43,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/P/d/7/fab096/pd-g5building.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Perfect%20Dark%20UT/G/d/7/fab096/pd-g5building.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Single Player/D/c/8/b1cca5/dm-jt-trainingday_[c8b1cca5].yml
+++ b/content/Unreal Tournament/Maps/Single Player/D/c/8/b1cca5/dm-jt-trainingday_[c8b1cca5].yml
@@ -32,10 +32,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/DeathMatch/J/c/8/b1cca5/DM-JT-TrainingDay.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Single%20Player/D/c/8/b1cca5/DM-JT-TrainingDay.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Single Player/W/b/5/24da66/wtf_[b524da66].yml
+++ b/content/Unreal Tournament/Maps/Single Player/W/b/5/24da66/wtf_[b524da66].yml
@@ -256,10 +256,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/W/b/5/24da66/UTWTFSeries1.rar"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Single%20Player/W/b/5/24da66/UTWTFSeries1.rar"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tactical Ops/A/2/7/54fc8d/sw-airportterror_[2754fc8d].yml
+++ b/content/Unreal Tournament/Maps/Tactical Ops/A/2/7/54fc8d/sw-airportterror_[2754fc8d].yml
@@ -53,10 +53,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/S/2/7/54fc8d/TO-AirportTerror.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/A/2/7/54fc8d/TO-AirportTerror.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tactical Ops/A/a/4/69ceb2/swamp-logo_[a469ceb2].yml
+++ b/content/Unreal Tournament/Maps/Tactical Ops/A/a/4/69ceb2/swamp-logo_[a469ceb2].yml
@@ -41,10 +41,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/S/a/4/69ceb2/swamp-logo.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/A/a/4/69ceb2/swamp-logo.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tactical Ops/B/b/7/8a7b13/sw-buttfuckbackyard_[b78a7b13].yml
+++ b/content/Unreal Tournament/Maps/Tactical Ops/B/b/7/8a7b13/sw-buttfuckbackyard_[b78a7b13].yml
@@ -47,10 +47,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/S/b/7/8a7b13/TO-ButtFuckBackyard.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/B/b/7/8a7b13/TO-ButtFuckBackyard.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tactical Ops/C/3/9/660778/sw-chemical_warfare_facility_[39660778].yml
+++ b/content/Unreal Tournament/Maps/Tactical Ops/C/3/9/660778/sw-chemical_warfare_facility_[39660778].yml
@@ -59,10 +59,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/S/3/9/660778/sw-chemical_warfare_facility.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/C/3/9/660778/sw-chemical_warfare_facility.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tactical Ops/C/5/2/d4e55d/sw-cave_escape_[52d4e55d].yml
+++ b/content/Unreal Tournament/Maps/Tactical Ops/C/5/2/d4e55d/sw-cave_escape_[52d4e55d].yml
@@ -50,10 +50,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/S/5/2/d4e55d/sw-caveescape.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/C/5/2/d4e55d/sw-caveescape.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tactical Ops/C/9/d/b1fc17/sw-citystreetlarge_[9db1fc17].yml
+++ b/content/Unreal Tournament/Maps/Tactical Ops/C/9/d/b1fc17/sw-citystreetlarge_[9db1fc17].yml
@@ -56,10 +56,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/S/9/d/b1fc17/sw-citystreetlarge.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/C/9/d/b1fc17/sw-citystreetlarge.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tactical Ops/D/4/6/f62234/sw-downtown_[46f62234].yml
+++ b/content/Unreal Tournament/Maps/Tactical Ops/D/4/6/f62234/sw-downtown_[46f62234].yml
@@ -63,10 +63,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/S/4/6/f62234/sw-downtown.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/D/4/6/f62234/sw-downtown.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tactical Ops/F/d/d/68bcc9/sw-factory_[dd68bcc9].yml
+++ b/content/Unreal Tournament/Maps/Tactical Ops/F/d/d/68bcc9/sw-factory_[dd68bcc9].yml
@@ -66,10 +66,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/S/d/d/68bcc9/sw-factory.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/F/d/d/68bcc9/sw-factory.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tactical Ops/M/d/7/f3f9bf/sw-mallrats_[d7f3f9bf].yml
+++ b/content/Unreal Tournament/Maps/Tactical Ops/M/d/7/f3f9bf/sw-mallrats_[d7f3f9bf].yml
@@ -52,10 +52,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/S/d/7/f3f9bf/sw-mallrats.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/M/d/7/f3f9bf/sw-mallrats.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tactical Ops/R/d/4/b7777f/sw-rooftopassault_[d4b7777f].yml
+++ b/content/Unreal Tournament/Maps/Tactical Ops/R/d/4/b7777f/sw-rooftopassault_[d4b7777f].yml
@@ -111,10 +111,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/S/d/4/b7777f/sw-rooftopassault.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/R/d/4/b7777f/sw-rooftopassault.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tactical Ops/U/b/c/5fd0af/sw-underground_v3_[bc5fd0af].yml
+++ b/content/Unreal Tournament/Maps/Tactical Ops/U/b/c/5fd0af/sw-underground_v3_[bc5fd0af].yml
@@ -60,10 +60,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/S/b/c/5fd0af/TO-Underground.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/U/b/c/5fd0af/TO-Underground.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tactical Ops/W/1/3/21e376/sw-wiferxl_[1321e376].yml
+++ b/content/Unreal Tournament/Maps/Tactical Ops/W/1/3/21e376/sw-wiferxl_[1321e376].yml
@@ -81,10 +81,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/S/1/3/21e376/sw-wiferxl.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tactical%20Ops/W/1/3/21e376/sw-wiferxl.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tests and Demos/A/2/7/c944e5/as-skaarjattackmsu_[27c944e5].yml
+++ b/content/Unreal Tournament/Maps/Tests and Demos/A/2/7/c944e5/as-skaarjattackmsu_[27c944e5].yml
@@ -36,10 +36,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Assault/S/2/7/c944e5/AS-SkaarjAttack!MSU.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tests%20and%20Demos/A/2/7/c944e5/AS-SkaarjAttack!MSU.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tests and Demos/A/2/d/d04cec/as-komodoa-006_[2dd04cec].yml
+++ b/content/Unreal Tournament/Maps/Tests and Demos/A/2/d/d04cec/as-komodoa-006_[2dd04cec].yml
@@ -36,10 +36,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Assault/K/2/d/d04cec/AS-Komodo%5Ba-006%5D.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tests%20and%20Demos/A/2/d/d04cec/AS-Komodo%5Ba-006%5D.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tests and Demos/A/8/e/3a4dd9/as-olympics-solo_[8e3a4dd9].yml
+++ b/content/Unreal Tournament/Maps/Tests and Demos/A/8/e/3a4dd9/as-olympics-solo_[8e3a4dd9].yml
@@ -36,10 +36,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Assault/O/8/e/3a4dd9/AS-olympics-solo.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tests%20and%20Demos/A/8/e/3a4dd9/AS-olympics-solo.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tests and Demos/A/c/4/94f42c/astorm_[c494f42c].yml
+++ b/content/Unreal Tournament/Maps/Tests and Demos/A/c/4/94f42c/astorm_[c494f42c].yml
@@ -41,10 +41,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Assault/T/c/4/94f42c/AStorm.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tests%20and%20Demos/A/c/4/94f42c/AStorm.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tests and Demos/A/d/9/0dd6f7/as-skaarjattackmsu_[d90dd6f7].yml
+++ b/content/Unreal Tournament/Maps/Tests and Demos/A/d/9/0dd6f7/as-skaarjattackmsu_[d90dd6f7].yml
@@ -49,10 +49,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Assault/S/d/9/0dd6f7/as-skaarjattackmsu.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tests%20and%20Demos/A/d/9/0dd6f7/as-skaarjattackmsu.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tests and Demos/M/0/1/bd1f8e/mh-uktown_[01bd1f8e].yml
+++ b/content/Unreal Tournament/Maps/Tests and Demos/M/0/1/bd1f8e/mh-uktown_[01bd1f8e].yml
@@ -174,10 +174,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Monster%20Hunt/U/0/1/bd1f8e/mh-uktown.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tests%20and%20Demos/M/0/1/bd1f8e/mh-uktown.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tests and Demos/M/0/9/23404e/mh-testmap_[0923404e].yml
+++ b/content/Unreal Tournament/Maps/Tests and Demos/M/0/9/23404e/mh-testmap_[0923404e].yml
@@ -37,10 +37,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Monster%20Hunt/T/0/9/23404e/mh-testmap.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tests%20and%20Demos/M/0/9/23404e/mh-testmap.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tests and Demos/M/2/9/d75d5c/mh-umhcrashmap1_[29d75d5c].yml
+++ b/content/Unreal Tournament/Maps/Tests and Demos/M/2/9/d75d5c/mh-umhcrashmap1_[29d75d5c].yml
@@ -63,10 +63,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Monster%20Hunt/U/2/9/d75d5c/MH-UMHCrashmap1.unr.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tests%20and%20Demos/M/2/9/d75d5c/MH-UMHCrashmap1.unr.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tests and Demos/M/5/2/2441d0/mh-wpdemo_[522441d0].yml
+++ b/content/Unreal Tournament/Maps/Tests and Demos/M/5/2/2441d0/mh-wpdemo_[522441d0].yml
@@ -36,10 +36,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Monster%20Hunt/W/5/2/2441d0/MH-WPDemo.7z"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tests%20and%20Demos/M/5/2/2441d0/MH-WPDemo.7z"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tests and Demos/M/5/5/be1ae3/mh-monsterbuguer_demo_[55be1ae3].yml
+++ b/content/Unreal Tournament/Maps/Tests and Demos/M/5/5/be1ae3/mh-monsterbuguer_demo_[55be1ae3].yml
@@ -39,10 +39,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Monster%20Hunt/M/5/5/be1ae3/MH-MonsterBuguer_Demo.7z"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tests%20and%20Demos/M/5/5/be1ae3/MH-MonsterBuguer_Demo.7z"
   main: false
   repack: false

--- a/content/Unreal Tournament/Maps/Tests and Demos/M/d/e/b8aa56/mh-dawn2_[deb8aa56].yml
+++ b/content/Unreal Tournament/Maps/Tests and Demos/M/d/e/b8aa56/mh-dawn2_[deb8aa56].yml
@@ -37,10 +37,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Monster%20Hunt/D/d/e/b8aa56/mh-dawn2.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Tests%20and%20Demos/M/d/e/b8aa56/mh-dawn2.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Mutators/B/4/0/3f9434/bullet-time-300-raw_[403f9434].yml
+++ b/content/Unreal Tournament/Mutators/B/4/0/3f9434/bullet-time-300-raw_[403f9434].yml
@@ -49,10 +49,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Mutators/0/4/0/3f9434/451_BulletTime300_Raw.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Mutators/B/4/0/3f9434/451_BulletTime300_Raw.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Mutators/B/7/3/7ffb65/bullet-time-300-umod_[737ffb65].yml
+++ b/content/Unreal Tournament/Mutators/B/7/3/7ffb65/bullet-time-300-umod_[737ffb65].yml
@@ -59,10 +59,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Mutators/0/7/3/7ffb65/451_BulletTime300_Umod.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Mutators/B/7/3/7ffb65/451_BulletTime300_Umod.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Mutators/C/3/c/28e42c/cosmic_[3c28e42c].yml
+++ b/content/Unreal Tournament/Mutators/C/3/c/28e42c/cosmic_[3c28e42c].yml
@@ -70,10 +70,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal/Mutators/C/3/c/28e42c/cosmic300.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Mutators/C/3/c/28e42c/cosmic300.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Mutators/M/b/7/717151/mind-reader_[b7717151].yml
+++ b/content/Unreal Tournament/Mutators/M/b/7/717151/mind-reader_[b7717151].yml
@@ -34,10 +34,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal/Mutators/M/b/7/717151/mindreader.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Mutators/M/b/7/717151/mindreader.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Mutators/M/c/0/632bfd/mind-reader_[c0632bfd].yml
+++ b/content/Unreal Tournament/Mutators/M/c/0/632bfd/mind-reader_[c0632bfd].yml
@@ -29,10 +29,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal/Mutators/M/c/0/632bfd/mindreader.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Mutators/M/c/0/632bfd/mindreader.zip"
   main: false
   repack: false

--- a/content/Unreal Tournament/Mutators/S/e/d/530bac/spacemarinez-106_[ed530bac].yml
+++ b/content/Unreal Tournament/Mutators/S/e/d/530bac/spacemarinez-106_[ed530bac].yml
@@ -36,10 +36,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal/Mutators/S/e/d/530bac/UMSSpaceMarine106.rar"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Mutators/S/e/d/530bac/UMSSpaceMarine106.rar"
   main: false
   repack: false

--- a/content/Unreal/MapPacks/D/0/8/535464/de-bonus-pack-unreal-version_[08535464].yml
+++ b/content/Unreal/MapPacks/D/0/8/535464/de-bonus-pack-unreal-version_[08535464].yml
@@ -56,10 +56,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal/MapPacks/C/0/8/535464/ctfmaps.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal/MapPacks/D/0/8/535464/ctfmaps.zip"
   main: false
   repack: false

--- a/content/Unreal/Maps/Single Player/C/8/d/c14043/chamberofchoice_[8dc14043].yml
+++ b/content/Unreal/Maps/Single Player/C/8/d/c14043/chamberofchoice_[8dc14043].yml
@@ -30,10 +30,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal%20Tournament/Maps/Unknown/C/8/d/c14043/chamberofchoice.rar"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal/Maps/Single%20Player/C/8/d/c14043/chamberofchoice.rar"
   main: false
   repack: false

--- a/content/Unreal/Mutators/P/5/8/92a92e/patrick-gorgor-cyr_[5892a92e].yml
+++ b/content/Unreal/Mutators/P/5/8/92a92e/patrick-gorgor-cyr_[5892a92e].yml
@@ -30,10 +30,6 @@ downloads:
   main: false
   repack: false
   state: "OK"
-- url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal/Mutators/B/5/8/92a92e/botwatcher.zip"
-  main: false
-  repack: false
-  state: "OK"
 - url: "https://unrealarchiveusa.blob.core.windows.net/files/Unreal/Mutators/P/5/8/92a92e/botwatcher.zip"
   main: false
   repack: false


### PR DESCRIPTION
Remove duplicate Azure mirrors due to rename of files which caused the file to be mirrored again under a different path.

Updated the files using this basic script: https://gist.github.com/richardsondev/b43abda4fbea78308e707ca62687880f

