### PR TITLE
Critical Fixes (2023-02-15)

### DIFF
--- a/content/Unreal Tournament 2004/Mutators/A/4/7/bd76e5/allows-you-to-configure-your-amount-of-grenades-after-spawn_[47bd76e5].yml
+++ b/content/Unreal Tournament 2004/Mutators/A/4/7/bd76e5/allows-you-to-configure-your-amount-of-grenades-after-spawn_[47bd76e5].yml
@@ -2,9 +2,9 @@
 contentType: "MUTATOR"
 firstIndex: "2023-02-11 23:06"
 game: "Unreal Tournament 2004"
-name: "Allows you to configure your amount of Grenades after Spawn!"
-author: "Unknown"
-description: ""
+name: "SpawnGrenade"
+author: "TNSe"
+description: "Allows you to configure your amount of Grenades after Spawn!"
 releaseDate: "2004-04"
 attachments: []
 originalFilename: "spawngrenades.rar"
@@ -24,8 +24,8 @@ downloads:
 links: {}
 deleted: false
 mutators:
-- name: "Allows you to configure your amount of Grenades after Spawn!"
-  description: ""
+- name: "SpawnGrenade"
+  description: "Allows you to configure your amount of Grenades after Spawn!"
 weapons: []
 vehicles: []
 hasConfigMenu: false

--- a/content/Unreal Tournament 2004/Mutators/A/a/5/5978e4/arena-with-the-omfg-gun-oh-my-dear-god-sir2004-rachel-angel-mapper-cordone_[a55978e4].yml
+++ b/content/Unreal Tournament 2004/Mutators/A/a/5/5978e4/arena-with-the-omfg-gun-oh-my-dear-god-sir2004-rachel-angel-mapper-cordone_[a55978e4].yml
@@ -2,9 +2,9 @@
 contentType: "MUTATOR"
 firstIndex: "2023-02-12 01:48"
 game: "Unreal Tournament 2004"
-name: "Arena with the OMFG Gun.  Oh my dear god sir.||2004 Rachel 'Angel Mapper' Cordone"
-author: "Unknown"
-description: ""
+name: "OMFG Gun 2k4"
+author: "Rachel 'Angel Mapper' Cordone"
+description: "Arena with the OMFG Gun.  Oh my dear god sir."
 releaseDate: "2004-04"
 attachments: []
 originalFilename: "OMFG2k4.zip"
@@ -24,9 +24,8 @@ downloads:
 links: {}
 deleted: false
 mutators:
-- name: "Arena with the OMFG Gun.  Oh my dear god sir.||2004 Rachel 'Angel Mapper'\
-    \ Cordone"
-  description: ""
+- name: "OMFG Gun 2k4"
+  description: "Arena with the OMFG Gun.  Oh my dear god sir."
 weapons: []
 vehicles: []
 hasConfigMenu: false

--- a/content/Unreal Tournament 2004/Mutators/M/f/f/87fc7d/mapmixer_[ff87fc7d].yml
+++ b/content/Unreal Tournament 2004/Mutators/M/f/f/87fc7d/mapmixer_[ff87fc7d].yml
@@ -2,12 +2,10 @@
 contentType: "MUTATOR"
 firstIndex: "2023-02-12 02:49"
 game: "Unreal Tournament 2004"
-name: "MapMixer"
-author: "the navigation"
-description: "MapMixer gives you extended control of Maps, Game Types, Mutators, Player\
-  \ Counts and more...||Version: 2.00 (4 June 2004)|http://mapmixer.unrealtournament2004.com.au||Full\
-  \ documentation is included in the help folder"
-releaseDate: "2004-06"
+name: "MapMixer 2.00"
+author: "sinx"
+description: "MapMixer gives you extended control of Maps, Game Types, Mutators, Player Counts and more..."
+releaseDate: "2004-06-04"
 attachments:
 - type: "IMAGE"
   name: "mapmixer_shot_ff87fc7d_4.png"
@@ -57,9 +55,7 @@ links: {}
 deleted: false
 mutators:
 - name: "MapMixer"
-  description: "MapMixer gives you extended control of Maps, Game Types, Mutators,\
-    \ Player Counts and more...||Version: 2.00 (4 June 2004)|http://mapmixer.unrealtournament2004.com.au||Full\
-    \ documentation is included in the help folder"
+  description: "MapMixer gives you extended control of Maps, Game Types, Mutators, Player Counts and more..."
 weapons: []
 vehicles: []
 hasConfigMenu: false

--- a/content/Unreal Tournament 2004/Mutators/U/d/5/d198e5/u4e-msu-edition_[d5d198e5].yml
+++ b/content/Unreal Tournament 2004/Mutators/U/d/5/d198e5/u4e-msu-edition_[d5d198e5].yml
@@ -2,7 +2,7 @@
 contentType: "MUTATOR"
 firstIndex: "2023-02-11 22:31"
 game: "Unreal Tournament 2004"
-name: "U4e Msu Edition"
+name: "Unreal4Ever (MSU Edition)"
 author: "-goro\""
 description: "None"
 releaseDate: "2004-06"

--- a/content/Unreal Tournament 2004/Voices/P/d/7/a6d4a1/portal-by-jamesa_[d7a6d4a1].yml
+++ b/content/Unreal Tournament 2004/Voices/P/d/7/a6d4a1/portal-by-jamesa_[d7a6d4a1].yml
@@ -2,8 +2,8 @@
 contentType: "VOICE"
 firstIndex: "2023-02-12 00:25"
 game: "Unreal Tournament 2004"
-name: "Portal By James.A"
-author: "Unknown"
+name: "Portal"
+author: "James.A"
 description: "None"
 releaseDate: "2009-07"
 attachments: []
@@ -24,4 +24,4 @@ downloads:
 links: {}
 deleted: false
 voices:
-- "\"Portal By James.A\""
+- "Portal"

--- a/content/Unreal Tournament 2004/Voices/Y/5/1/aba9b0/yu-gi-oh-the-abridged-series-voice-pack_[51aba9b0].yml
+++ b/content/Unreal Tournament 2004/Voices/Y/5/1/aba9b0/yu-gi-oh-the-abridged-series-voice-pack_[51aba9b0].yml
@@ -2,7 +2,7 @@
 contentType: "VOICE"
 firstIndex: "2023-02-06 15:41"
 game: "Unreal Tournament 2004"
-name: "Yu gi oh the abridged series voice pack"
+name: "Yu-Gi-Oh! The Abridged Series Voice Pack"
 author: "Unknown"
 description: "None"
 releaseDate: "2007-10"
@@ -24,4 +24,4 @@ downloads:
 links: {}
 deleted: false
 voices:
-- "\"Yu gi oh the abridged series voice pack\""
+- "Yu-Gi-Oh! The Abridged Series Voice Pack"

--- a/content/Unreal Tournament 3/Maps/DeathMatch/C/4/9/8fd57a/dm-crate_[498fd57a].yml
+++ b/content/Unreal Tournament 3/Maps/DeathMatch/C/4/9/8fd57a/dm-crate_[498fd57a].yml
@@ -48,7 +48,7 @@ downloads:
   state: "OK"
 links: {}
 deleted: false
-gametype: "DeathMatch"
+gametype: "Tests and Demos"
 title: "Surprise Gift"
 playerCount: "Unknown"
 themes: {}

--- a/content/Unreal Tournament 3/Mutators/M/5/a/643879/mutzoominstagib-v1-0_[5a643879].yml
+++ b/content/Unreal Tournament 3/Mutators/M/5/a/643879/mutzoominstagib-v1-0_[5a643879].yml
@@ -2,7 +2,7 @@
 contentType: "MUTATOR"
 firstIndex: "2023-02-05 22:00"
 game: "Unreal Tournament 3"
-name: "MutZoomInstaGib V1 0"
+name: "Zoom InstaGib V1.0"
 author: "VladTepz"
 description: "None"
 releaseDate: "2007-11"

--- a/content/Unreal Tournament 3/Mutators/S/2/c/a3477d/spam-protector-ut3-version_[2ca3477d].yml
+++ b/content/Unreal Tournament 3/Mutators/S/2/c/a3477d/spam-protector-ut3-version_[2ca3477d].yml
@@ -3,8 +3,8 @@ contentType: "MUTATOR"
 firstIndex: "2023-02-05 18:10"
 game: "Unreal Tournament 3"
 name: "Spam Protector (UT3 Version)"
-author: "Unknown"
-description: "Tries to prevent spamming. Coded by Gugi."
+author: "Gugi"
+description: "Tries to prevent spamming."
 releaseDate: "2007-11"
 attachments: []
 originalFilename: "SpamProtect3_v1a.zip"
@@ -25,7 +25,7 @@ links: {}
 deleted: false
 mutators:
 - name: "Spam Protector (UT3 Version)"
-  description: "Tries to prevent spamming. Coded by Gugi."
+  description: "Tries to prevent spamming."
 weapons: []
 vehicles: []
 hasConfigMenu: false

--- a/content/Unreal Tournament 3/Mutators/S/2/c/a3477d/spam-protector-ut3-version_[2ca3477d].yml
+++ b/content/Unreal Tournament 3/Mutators/S/2/c/a3477d/spam-protector-ut3-version_[2ca3477d].yml
@@ -2,7 +2,7 @@
 contentType: "MUTATOR"
 firstIndex: "2023-02-05 18:10"
 game: "Unreal Tournament 3"
-name: "Spam Protector UT3 Version"
+name: "Spam Protector (UT3 Version)"
 author: "Unknown"
 description: "Tries to prevent spamming. Coded by Gugi."
 releaseDate: "2007-11"
@@ -24,7 +24,7 @@ downloads:
 links: {}
 deleted: false
 mutators:
-- name: "Spam Protector UT3 Version"
+- name: "Spam Protector (UT3 Version)"
   description: "Tries to prevent spamming. Coded by Gugi."
 weapons: []
 vehicles: []

--- a/content/Unreal Tournament/Maps/Capture The Flag/U/7/0/6cd434/ctf-utdm-morbias_[706cd434].yml
+++ b/content/Unreal Tournament/Maps/Capture The Flag/U/7/0/6cd434/ctf-utdm-morbias_[706cd434].yml
@@ -3,7 +3,7 @@ contentType: "MAP"
 firstIndex: "2023-02-03 22:45"
 game: "Unreal Tournament"
 name: "CTF-UTDM-Morbias"
-author: "Myscha made · edited by EvilGrins"
+author: "T. Elliott 'Myscha' Cannon, EvilGrins (UTDM exit), Nelsona (botpathing)"
 description: "None"
 releaseDate: "2022-05"
 attachments:
@@ -57,7 +57,7 @@ links: {}
 deleted: false
 gametype: "Capture The Flag"
 title: "Morbias UTDM-monsters Edition"
-playerCount: "pathed by Nelsona · 8-10"
+playerCount: "8-10"
 themes:
   Skaarj Tech: 1.0
 bots: true

--- a/content/Unreal Tournament/Maps/DeathMatch/U/f/b/8ac604/dm-utdmt-bunnyrabbitstew_[fb8ac604].yml
+++ b/content/Unreal Tournament/Maps/DeathMatch/U/f/b/8ac604/dm-utdmt-bunnyrabbitstew_[fb8ac604].yml
@@ -3,7 +3,7 @@ contentType: "MAP"
 firstIndex: "2023-02-03 22:45"
 game: "Unreal Tournament"
 name: "DM-UTDMT-BunnyRabbitStew"
-author: "sAlleYdEth made · edited by EvilGrins"
+author: "sAlleYdEth, EvilGrins (UTDMT edit), Nelsona (botpathing)"
 description: "None"
 releaseDate: "2022-05"
 attachments:
@@ -58,7 +58,7 @@ links: {}
 deleted: false
 gametype: "DeathMatch"
 title: "Henry's Revenge"
-playerCount: "pathed by Nelsona · More than 5"
+playerCount: "5+"
 themes:
   Skaarj Tech: 0.1
   Ancient: 0.9

--- a/content/Unreal Tournament/Maps/Unknown/T/2/3/ebe285/templechambers_[23ebe285].yml
+++ b/content/Unreal Tournament/Maps/Unknown/T/2/3/ebe285/templechambers_[23ebe285].yml
@@ -23,7 +23,7 @@ downloads:
   state: "OK"
 links: {}
 deleted: false
-gametype: "Deathmatch"
+gametype: "DeathMatch"
 title: "Temple Chambers"
 playerCount: "2-8"
 themes:


### PR DESCRIPTION
This fixes a CRITICAL problem where the UT99 Deathmatch maps wouldn't be displayed due to TempleChambers being named "Deathmatch" rather than "DeathMatch".

Also fixed many author and asset names and descriptions, as well as a fix for #2477 .