### PR TITLE
carlaunch7z_2bf40d70

### DIFF
--- a/content/Unreal Tournament 2004/MapPacks/U/f/1/92dd06/utclassics_[f192dd06].yml
+++ b/content/Unreal Tournament 2004/MapPacks/U/f/1/92dd06/utclassics_[f192dd06].yml
@@ -1,0 +1,139 @@
+--- !<MAP_PACK>
+contentType: "MAP_PACK"
+firstIndex: "2024-02-02 13:43"
+game: "Unreal Tournament 2004"
+name: "UTClassics"
+author: "MsM"
+description: "None"
+releaseDate: "2004-01"
+attachments:
+- type: "IMAGE"
+  name: "utclassics_shot_f192dd06_2.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/U/f/1/92dd06/utclassics_shot_f192dd06_2.png"
+- type: "IMAGE"
+  name: "utclassics_shot_f192dd06_6.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/U/f/1/92dd06/utclassics_shot_f192dd06_6.png"
+- type: "IMAGE"
+  name: "utclassics_shot_f192dd06_5.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/U/f/1/92dd06/utclassics_shot_f192dd06_5.png"
+- type: "IMAGE"
+  name: "utclassics_shot_f192dd06_1.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/U/f/1/92dd06/utclassics_shot_f192dd06_1.png"
+- type: "IMAGE"
+  name: "utclassics_shot_f192dd06_8.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/U/f/1/92dd06/utclassics_shot_f192dd06_8.png"
+- type: "IMAGE"
+  name: "utclassics_shot_f192dd06_10.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/U/f/1/92dd06/utclassics_shot_f192dd06_10.png"
+- type: "IMAGE"
+  name: "utclassics_shot_f192dd06_11.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/U/f/1/92dd06/utclassics_shot_f192dd06_11.png"
+- type: "IMAGE"
+  name: "utclassics_shot_f192dd06_12.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/U/f/1/92dd06/utclassics_shot_f192dd06_12.png"
+- type: "IMAGE"
+  name: "utclassics_shot_f192dd06_7.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/U/f/1/92dd06/utclassics_shot_f192dd06_7.png"
+- type: "IMAGE"
+  name: "utclassics_shot_f192dd06_4.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/U/f/1/92dd06/utclassics_shot_f192dd06_4.png"
+- type: "IMAGE"
+  name: "utclassics_shot_f192dd06_9.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/U/f/1/92dd06/utclassics_shot_f192dd06_9.png"
+- type: "IMAGE"
+  name: "utclassics_shot_f192dd06_3.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/U/f/1/92dd06/utclassics_shot_f192dd06_3.png"
+originalFilename: "UTClassics.7z"
+hash: "f192dd0609ad918589fa772a280a6e81710bf6e8"
+fileSize: 38791218
+files:
+- name: "DM-Gothic2k3.ut2"
+  fileSize: 18883965
+  hash: "263a04bf9a6dd02793e3f3c81384700957ac52cd"
+- name: "DOM-Cinder2.ut2"
+  fileSize: 7809540
+  hash: "a34ea87ec98979b3329731a05ae45178a6971dd8"
+- name: "Razor-ub.ogg"
+  fileSize: 3443841
+  hash: "a1b70d3c8ee12ac5900aee01accec87c8dea651c"
+- name: "DM-Arcane_Temple2k3.ut2"
+  fileSize: 16691371
+  hash: "19156e496209d02d1ea591a648cc06e8bccf6ef6"
+- name: "Lock.ogg"
+  fileSize: 1977508
+  hash: "537982647e917da5c029b41136806b123b3534a3"
+- name: "Nether.ogg"
+  fileSize: 3620673
+  hash: "0968b0572ee558c0282df24ba1bcc2e20600e1b9"
+- name: "decayed.usx"
+  fileSize: 1016456
+  hash: "b3282294930c48969e874b09314d881ed26401e9"
+- name: "R3tex.utx"
+  fileSize: 18411222
+  hash: "5982bd56f81954a05e5fcd7624a1428f95e4bf83"
+- name: "DM-1on1Oblivion2k3.ut2"
+  fileSize: 3526096
+  hash: "8449d271f4a93fa9e7c9fb4c57c574fa2ef4eaa7"
+- name: "CTF-Oblivion.ut2"
+  fileSize: 8102692
+  hash: "f11e3d9747e8df5204377f9129b344257ec363dc"
+- name: "R3meshes.usx"
+  fileSize: 7198368
+  hash: "4cd3b818c8bb310e793e837a592600ead2ba6aa9"
+- name: "firebr.ogg"
+  fileSize: 2339149
+  hash: "894427b6e3b24fac4288929ef2f1de0c36deebd7"
+- name: "KR-Run.ogg"
+  fileSize: 11841885
+  hash: "59ef88491c801d0a503b7516129773c80313a6e3"
+- name: "DM-Shrapnel][2k3.ut2"
+  fileSize: 9050224
+  hash: "d11c41109e6a76e23a95af6c47a67e571b7b004f"
+otherFiles: 7
+dependencies:
+  DM-1on1Oblivion2k3.ut2:
+  - status: "OK"
+    name: "decayed"
+  CTF-Oblivion.ut2:
+  - status: "OK"
+    name: "decayed"
+  R3meshes.usx:
+  - status: "OK"
+    name: "R3tex"
+  DOM-Cinder2.ut2:
+  - status: "OK"
+    name: "decayed"
+  DM-Gothic2k3.ut2:
+  - status: "OK"
+    name: "R3meshes"
+downloads:
+- url: "https://unreal-archive-files-s3.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/U/f/1/92dd06/UTClassics.7z"
+  direct: true
+  state: "OK"
+links: {}
+deleted: false
+maps:
+- name: "DM-Gothic2k3"
+  title: "Gothic"
+  author: "MsM"
+- name: "DOM-Cinder2"
+  title: "Cinder 2"
+  author: "MsM"
+- name: "DM-Arcane_Temple2k3"
+  title: "Arcane Temple"
+  author: "MsM"
+- name: "DM-1on1Oblivion2k3"
+  title: "1on1 Oblivion"
+  author: "MsM"
+- name: "CTF-Oblivion"
+  title: "Oblivion"
+  author: "MsM"
+- name: "DM-Shrapnel][2k3"
+  title: "Shrapnel Metal Compound"
+  author: "MsM"
+gametype: "Mixed"
+themes:
+  Tech: 0.3
+  Industrial: 0.4
+  Egyptian: 0.1
+  Ancient: 0.3

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/C/f/6/d6e6aa/ctf-coret1999ad_[f6d6e6aa].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/C/f/6/d6e6aa/ctf-coret1999ad_[f6d6e6aa].yml
@@ -1,0 +1,64 @@
+--- !<MAP>
+contentType: "MAP"
+firstIndex: "2024-02-02 13:43"
+game: "Unreal Tournament 2004"
+name: "CTF-Coret1999AD"
+author: "Dave 'Sir_Dave' van Lienen"
+description: "Captain's Log - Stardate: 62468||Since the battle of Unreal Tournament\
+  \ 2003 had started, many races wanted to become the best.||During the finals, only\
+  \ two races proofed to be the best. It was the Humans vs the Artificial Life Form.\
+  \ Cause the ALF was still in its own developing stage, the Humans won the finals.||The\
+  \ ALF studied their greatest adversaries and asked for a rematch. The Humans kicked\
+  \ some ALF ass some time ago and were happy to do it again. Sadly for the ALF, they\
+  \ got their asses kicked again by the same group of Humans.||After the ALF knew\
+  \ they were no match for these days Humans, they wanted to know why the Human race\
+  \ was always anticipating that good during different kind of scenarios. So they\
+  \ did a big background check of the Human race.||After some research, they found\
+  \ out that the humans skills developed rapidly cause of an old and ancient map called\
+  \ Coret Facility. The ALF tried to find that place, but when they did it was all\
+  \ messed up cause of all the training that took place since 1999 AD. They trained\
+  \ in this map but it didn't take long until they found out that it wasn't the same\
+  \ as it was in the older days when the Humans trained there. The ALF could only\
+  \ read and learn from the history that was written, but they knew they needed more\
+  \ to match up against todays Humans.||So the ALF started working on a plan to get\
+  \ the old time map with the old time action. They placed a lot of work into various\
+  \ options but only one was the best \"GOING BACK INTO THE PAST\". The ALF secretly\
+  \ examined the translocator and managed to upgrade it to a Time Portal.||Now the\
+  \ ALF had the ability to travel through time. They gathered up the team and went\
+  \ towards the tournaments of 1999 where the great map CTF-Coret was in an un-wrecked\
+  \ stage. The ALF trained kick ass hard to get the best, and after some long training\
+  \ matches they were. The next step was to go back to their own time period and kick\
+  \ some Humans ass.||Cause of all the hard training in the past, they won all tournaments\
+  \ in the present, they were No. 1 game after game.||Soon the ALF were bored with\
+  \ kicking everybody's asses and wanted to have the same competitive feeling of the\
+  \ old matches again. So they knew that the other races needed to gain strength and\
+  \ tactics again. They decided to make a public time bridge between the present and\
+  \ the past's CTF-Coret map to make the adversaries of today worthy again.||That's\
+  \ how the kick ass map CTF-Coret from the old days, got back into the Unreal Tournament\
+  \ 2003 maplist known as CTF-Coret1999AD."
+releaseDate: "2007-10"
+attachments:
+- type: "IMAGE"
+  name: "ctf-coret1999ad_shot_f6d6e6aa_1.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/C/f/6/d6e6aa/ctf-coret1999ad_shot_f6d6e6aa_1.png"
+originalFilename: "CTF-Coret1999AD.7z"
+hash: "f6d6e6aa225879960babdc2df89a8a6db5e4c3de"
+fileSize: 3349265
+files:
+- name: "CTF-Coret1999AD.ut2"
+  fileSize: 15033812
+  hash: "a0f1fc6489712f76105a28b590f2f459671f9162"
+otherFiles: 0
+dependencies: {}
+downloads:
+- url: "https://unreal-archive-files-s3.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/C/f/6/d6e6aa/CTF-Coret1999AD.7z"
+  direct: true
+  state: "OK"
+links: {}
+deleted: false
+gametype: "Capture The Flag"
+title: "Coret Facility 1999AD"
+playerCount: "12"
+themes:
+  Tech: 1.0
+bots: true

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/F/a/d/51f542/ctf-flax_[ad51f542].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/F/a/d/51f542/ctf-flax_[ad51f542].yml
@@ -1,0 +1,39 @@
+--- !<MAP>
+contentType: "MAP"
+firstIndex: "2024-02-02 13:43"
+game: "Unreal Tournament 2004"
+name: "CTF-Flax"
+author: "John Meissner \"{-zX-}Grim_Angel"
+description: "None"
+releaseDate: "2003-12"
+attachments:
+- type: "IMAGE"
+  name: "ctf-flax_shot_ad51f542_1.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/F/a/d/51f542/ctf-flax_shot_ad51f542_1.png"
+originalFilename: "CTF-Flax.7z"
+hash: "ad51f5424cd6d2a466a3b90e2e289f63656b0f5f"
+fileSize: 1243496
+files:
+- name: "WetText.utx"
+  fileSize: 18878
+  hash: "c3748be849578d831814d885fb3ed86e6d86850d"
+- name: "CTF-Flax.ut2"
+  fileSize: 6370065
+  hash: "b527e29638fb342e7102003f8244a55d6a2b3654"
+otherFiles: 1
+dependencies:
+  CTF-Flax.ut2:
+  - status: "OK"
+    name: "WetText"
+downloads:
+- url: "https://unreal-archive-files-s3.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/F/a/d/51f542/CTF-Flax.7z"
+  direct: true
+  state: "OK"
+links: {}
+deleted: false
+gametype: "Capture The Flag"
+title: "CTF-Flax"
+playerCount: "6"
+themes:
+  Industrial: 1.0
+bots: true

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/M/7/4/8c7f9c/ctf-mini_[748c7f9c].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/M/7/4/8c7f9c/ctf-mini_[748c7f9c].yml
@@ -1,0 +1,30 @@
+--- !<MAP>
+contentType: "MAP"
+firstIndex: "2024-02-02 13:43"
+game: "Unreal Tournament 2004"
+name: "CTF-Mini"
+author: "Unknown"
+description: "None"
+releaseDate: "2002-10"
+attachments: []
+originalFilename: "ctf-mini.7z"
+hash: "748c7f9cf21519fb316c63e0d72c6f7364b04e74"
+fileSize: 100682
+files:
+- name: "CTF-Mini.ut2"
+  fileSize: 762911
+  hash: "547f9bd582e099092060beb5e8eae023f6c5eefc"
+otherFiles: 0
+dependencies: {}
+downloads:
+- url: "https://unreal-archive-files-s3.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/M/7/4/8c7f9c/ctf-mini.7z"
+  direct: true
+  state: "OK"
+links: {}
+deleted: false
+gametype: "Capture The Flag"
+title: "CTF-Mini"
+playerCount: "Unknown"
+themes:
+  Tech: 1.0
+bots: true

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/S/a/5/b6c4e9/ctf-spirit_[a5b6c4e9].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/S/a/5/b6c4e9/ctf-spirit_[a5b6c4e9].yml
@@ -1,0 +1,35 @@
+--- !<MAP>
+contentType: "MAP"
+firstIndex: "2024-02-02 13:43"
+game: "Unreal Tournament 2004"
+name: "CTF-Spirit"
+author: "Ryan (slipo666)"
+description: "This old Hettite temple was built in 1800 BC for housing, torturing\
+  \ and converting Egyptians. The Unreal Tournament commetee selected this as an arena\
+  \ for the competition."
+releaseDate: "2003-06"
+attachments:
+- type: "IMAGE"
+  name: "ctf-spirit_shot_a5b6c4e9_1.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/S/a/5/b6c4e9/ctf-spirit_shot_a5b6c4e9_1.png"
+originalFilename: "CTF-Spirit.7z"
+hash: "a5b6c4e9913ef9b0c427eb243080044384bbfedb"
+fileSize: 760279
+files:
+- name: "CTF-Spirit.ut2"
+  fileSize: 2908494
+  hash: "cd82535243582ece6884bec8e6b44c35c93f759c"
+otherFiles: 2
+dependencies: {}
+downloads:
+- url: "https://unreal-archive-files-s3.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Maps/Capture%20The%20Flag/S/a/5/b6c4e9/CTF-Spirit.7z"
+  direct: true
+  state: "OK"
+links: {}
+deleted: false
+gametype: "Capture The Flag"
+title: "Spirit 1.2"
+playerCount: "Unknown"
+themes:
+  Egyptian: 1.0
+bots: true

--- a/content/Unreal Tournament 2004/Maps/DeathMatch/0/3/5/2327c0/dm-1to1morbias_[352327c0].yml
+++ b/content/Unreal Tournament 2004/Maps/DeathMatch/0/3/5/2327c0/dm-1to1morbias_[352327c0].yml
@@ -1,0 +1,43 @@
+--- !<MAP>
+contentType: "MAP"
+firstIndex: "2024-02-02 13:43"
+game: "Unreal Tournament 2004"
+name: "DM-1to1Morbias"
+author: "m@yhem"
+description: "MORBIAS REMAKE"
+releaseDate: "2007-04"
+attachments:
+- type: "IMAGE"
+  name: "dm-1to1morbias_shot_352327c0_2.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Maps/DeathMatch/0/3/5/2327c0/dm-1to1morbias_shot_352327c0_2.png"
+- type: "IMAGE"
+  name: "dm-1to1morbias_shot_352327c0_1.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Maps/DeathMatch/0/3/5/2327c0/dm-1to1morbias_shot_352327c0_1.png"
+originalFilename: "DM-1to1Morbias.7z"
+hash: "352327c0c005361a1fcd0f7c250e789a9240a6c9"
+fileSize: 1314213
+files:
+- name: "morbias.usx"
+  fileSize: 3858
+  hash: "94854dbfb790128215c10eb97dd49bc3d65cb024"
+- name: "DM-1to1Morbias.ut2"
+  fileSize: 4626917
+  hash: "444ce01b4598ee26f0aaac7383513bbef5795c74"
+otherFiles: 2
+dependencies:
+  DM-1to1Morbias.ut2:
+  - status: "OK"
+    name: "morbias"
+downloads:
+- url: "https://unreal-archive-files-s3.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Maps/DeathMatch/0/3/5/2327c0/DM-1to1Morbias.7z"
+  direct: true
+  state: "OK"
+links: {}
+deleted: false
+gametype: "DeathMatch"
+title: "morbias"
+playerCount: "2-6"
+themes:
+  Tech: 0.3
+  Industrial: 0.7
+bots: true

--- a/content/Unreal Tournament 2004/Maps/DeathMatch/A/9/2/5ea02b/dm-atrophy_[925ea02b].yml
+++ b/content/Unreal Tournament 2004/Maps/DeathMatch/A/9/2/5ea02b/dm-atrophy_[925ea02b].yml
@@ -1,0 +1,36 @@
+--- !<MAP>
+contentType: "MAP"
+firstIndex: "2024-02-02 13:43"
+variationOf: "bca6754b85372a4a474833c43bc6bf5756526463"
+game: "Unreal Tournament 2004"
+name: "DM-Atrophy"
+author: "Anthony 'Bean' Nichols"
+description: "The Atrophos Aquaductus, or Ill-Nourished Aqueducts, once supplied many\
+  \ underground defectors of the Corporate Machine a healthy supply of untainted water.\
+  \ Selfish altercations between subterranean tribes have turned this once-nurtured\
+  \ territory into little more than a degenerated combat arena."
+releaseDate: "2004-01"
+attachments:
+- type: "IMAGE"
+  name: "dm-atrophy_shot_925ea02b_1.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Maps/DeathMatch/A/9/2/5ea02b/dm-atrophy_shot_925ea02b_1.png"
+originalFilename: "dm-atrophy.7z"
+hash: "925ea02b63bf9858cb3b6a1692bdf0a8f3222af0"
+fileSize: 3441064
+files:
+- name: "DM-Atrophy.ut2"
+  fileSize: 14443909
+  hash: "709fd68038eb020a131f6093ebd05a7b27d59497"
+otherFiles: 1
+dependencies: {}
+downloads:
+- url: "https://unreal-archive-files-s3.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Maps/DeathMatch/A/9/2/5ea02b/dm-atrophy.7z"
+  direct: true
+  state: "OK"
+links: {}
+deleted: false
+gametype: "DeathMatch"
+title: "DM-Atrophy"
+playerCount: "2-5"
+themes: {}
+bots: true

--- a/content/Unreal Tournament 2004/Maps/DeathMatch/C/5/a/bb762b/dm-curia_[5abb762b].yml
+++ b/content/Unreal Tournament 2004/Maps/DeathMatch/C/5/a/bb762b/dm-curia_[5abb762b].yml
@@ -1,0 +1,38 @@
+--- !<MAP>
+contentType: "MAP"
+firstIndex: "2024-02-02 13:43"
+game: "Unreal Tournament 2004"
+name: "DM-curia"
+author: "mayhem"
+description: "very tiny little map, few weapons. fast and mean1"
+releaseDate: "2007-10"
+attachments:
+- type: "IMAGE"
+  name: "dm-curia_shot_5abb762b_2.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Maps/DeathMatch/C/5/a/bb762b/dm-curia_shot_5abb762b_2.png"
+- type: "IMAGE"
+  name: "dm-curia_shot_5abb762b_1.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Maps/DeathMatch/C/5/a/bb762b/dm-curia_shot_5abb762b_1.png"
+originalFilename: "DM-curia.7z"
+hash: "5abb762b3b23fd520bcc2ce1274cde1306e80865"
+fileSize: 804459
+files:
+- name: "DM-curia.ut2"
+  fileSize: 3198882
+  hash: "4da569106e95a9877dcac91dadcd9b854f81b714"
+otherFiles: 2
+dependencies: {}
+downloads:
+- url: "https://unreal-archive-files-s3.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Maps/DeathMatch/C/5/a/bb762b/DM-curia.7z"
+  direct: true
+  state: "OK"
+links: {}
+deleted: false
+gametype: "DeathMatch"
+title: "DM-curia"
+playerCount: "2-4"
+themes:
+  Tech: 0.3
+  Industrial: 0.3
+  Ancient: 0.4
+bots: true

--- a/content/Unreal Tournament 2004/Maps/DeathMatch/C/a/f/f366c6/dm-citadelle_[aff366c6].yml
+++ b/content/Unreal Tournament 2004/Maps/DeathMatch/C/a/f/f366c6/dm-citadelle_[aff366c6].yml
@@ -1,0 +1,44 @@
+--- !<MAP>
+contentType: "MAP"
+firstIndex: "2024-02-02 13:43"
+game: "Unreal Tournament 2004"
+name: "DM-Citadelle"
+author: "m@yhem"
+description: "a small castle placed in a see, with some surprices | perfect for a\
+  \ strategical one to one play or a fast and mean battle with upto 4 players!"
+releaseDate: "2004-12"
+attachments:
+- type: "IMAGE"
+  name: "dm-citadelle_shot_aff366c6_2.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Maps/DeathMatch/C/a/f/f366c6/dm-citadelle_shot_aff366c6_2.png"
+- type: "IMAGE"
+  name: "dm-citadelle_shot_aff366c6_1.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Maps/DeathMatch/C/a/f/f366c6/dm-citadelle_shot_aff366c6_1.png"
+originalFilename: "DM-Citadelle.7z"
+hash: "aff366c6b3eab0222450f681ebe13611eab80c62"
+fileSize: 1637799
+files:
+- name: "DM-Citadelle.ut2"
+  fileSize: 6532710
+  hash: "2c9435c3b32b9d3c14d51d99c6c89acfb8188fcd"
+- name: "own.usx"
+  fileSize: 103223
+  hash: "69bea986b16680d6fffc9bebdb9973e5c9463dec"
+otherFiles: 2
+dependencies:
+  DM-Citadelle.ut2:
+  - status: "OK"
+    name: "own"
+downloads:
+- url: "https://unreal-archive-files-s3.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Maps/DeathMatch/C/a/f/f366c6/DM-Citadelle.7z"
+  direct: true
+  state: "OK"
+links: {}
+deleted: false
+gametype: "DeathMatch"
+title: "DM-Citadelle"
+playerCount: "2-4"
+themes:
+  Natural: 0.6
+  Industrial: 0.4
+bots: true

--- a/content/Unreal Tournament 2004/Maps/DeathMatch/C/e/c/ee4251/dm-campgrounds2003-te_[ecee4251].yml
+++ b/content/Unreal Tournament 2004/Maps/DeathMatch/C/e/c/ee4251/dm-campgrounds2003-te_[ecee4251].yml
@@ -1,0 +1,35 @@
+--- !<MAP>
+contentType: "MAP"
+firstIndex: "2024-02-02 13:43"
+game: "Unreal Tournament 2004"
+name: "DM-Campgrounds2003-TE"
+author: "id Software"
+description: "Tourney.it Edition|       Original Map by id Software|      UT2003 Conversion\
+  \ by epsil0n|     Modified By JollyRulez & Hormok."
+releaseDate: "2004-01"
+attachments:
+- type: "IMAGE"
+  name: "dm-campgrounds2003-te_shot_ecee4251_1.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Maps/DeathMatch/C/e/c/ee4251/dm-campgrounds2003-te_shot_ecee4251_1.png"
+originalFilename: "DM-Campgrounds2003-TE.7z"
+hash: "ecee42517ba967183487521970e73be17567918b"
+fileSize: 1253274
+files:
+- name: "DM-Campgrounds2003-TE.ut2"
+  fileSize: 6648895
+  hash: "061cb95b2dc1d766cc9f7a0e1b8a5ab8a3bc41b8"
+otherFiles: 1
+dependencies: {}
+downloads:
+- url: "https://unreal-archive-files-s3.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Maps/DeathMatch/C/e/c/ee4251/DM-Campgrounds2003-TE.7z"
+  direct: true
+  state: "OK"
+links: {}
+deleted: false
+gametype: "DeathMatch"
+title: "Campgrounds2003-TE"
+playerCount: "2-8"
+themes:
+  Industrial: 0.1
+  Ancient: 0.8
+bots: true

--- a/content/Unreal Tournament 2004/Mutators/M/0/1/903253/mutcarlaunch_[01903253].yml
+++ b/content/Unreal Tournament 2004/Mutators/M/0/1/903253/mutcarlaunch_[01903253].yml
@@ -1,0 +1,31 @@
+--- !<MUTATOR>
+contentType: "MUTATOR"
+firstIndex: "2024-02-02 13:42"
+game: "Unreal Tournament 2004"
+name: "MutCarLaunch"
+author: "Dezro"
+description: ""
+releaseDate: "2002-10"
+attachments: []
+originalFilename: "carlaunch.7z"
+hash: "019032534be0ac2fac4708dbc1ebe6196ecdff6d"
+fileSize: 5503
+files:
+- name: "CarLaunch.u"
+  fileSize: 13445
+  hash: "9804e869c89cd846f1f5e80c7e152c448276da53"
+otherFiles: 2
+dependencies: {}
+downloads:
+- url: "https://unreal-archive-files-s3.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Mutators/M/0/1/903253/carlaunch.7z"
+  direct: true
+  state: "OK"
+links: {}
+deleted: false
+mutators:
+- name: "MutCarLaunch"
+  description: ""
+weapons: []
+vehicles: []
+hasConfigMenu: false
+hasKeybinds: false

--- a/content/Unreal Tournament 2004/Mutators/M/3/2/f4b56c/-maps-converter-ctf-_[32f4b56c].yml
+++ b/content/Unreal Tournament 2004/Mutators/M/3/2/f4b56c/-maps-converter-ctf-_[32f4b56c].yml
@@ -1,0 +1,54 @@
+--- !<MUTATOR>
+contentType: "MUTATOR"
+firstIndex: "2024-02-02 13:43"
+game: "Unreal Tournament 2004"
+name: "'-= Maps Converter CTF =-'"
+author: "-=Musc@t=-"
+description: ""
+releaseDate: "2003-09"
+attachments:
+- type: "IMAGE"
+  name: "-maps-converter-ctf-_shot_32f4b56c_1.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Mutators/M/3/2/f4b56c/-maps-converter-ctf-_shot_32f4b56c_1.png"
+- type: "IMAGE"
+  name: "-maps-converter-ctf-_shot_32f4b56c_2.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Mutators/M/3/2/f4b56c/-maps-converter-ctf-_shot_32f4b56c_2.png"
+originalFilename: "MapsConverter100b5.zip"
+hash: "32f4b56c8453851ca7ed1201f38ce3f92dc18e74"
+fileSize: 196838
+files:
+- name: "MapsConverterFOStuff.u"
+  fileSize: 5166
+  hash: "53e099719c82894d6608728a4dc60e225181dbc2"
+- name: "ConverterPedestal.usx"
+  fileSize: 61069
+  hash: "dfc1c8968787b8472d861a58053fc023581f8243"
+- name: "MapsConverter100b5.u"
+  fileSize: 82461
+  hash: "1565463bbab4ab051ef1b388d42a5428857281db"
+- name: "MapsConverter100b5.ut2mod"
+  fileSize: 182125
+  hash: "35428ab839ae7bb2d2cb40f4c14a62bbcbaa6ed1"
+otherFiles: 8
+dependencies:
+  MapsConverter100b5.u:
+  - status: "OK"
+    name: "ConverterPedestal"
+  MapsConverterFOStuff.u:
+  - status: "OK"
+    name: "MapsConverter100b5"
+  - status: "MISSING"
+    name: "FaceOff"
+downloads:
+- url: "https://unreal-archive-files-s3.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Mutators/M/3/2/f4b56c/MapsConverter100b5.zip"
+  direct: true
+  state: "OK"
+links: {}
+deleted: false
+mutators:
+- name: "'-= Maps Converter CTF =-'"
+  description: ""
+weapons: []
+vehicles: []
+hasConfigMenu: false
+hasKeybinds: false

--- a/content/Unreal Tournament 2004/Mutators/P/6/8/98f69e/pinata2k3-is-a-remake-of-the-unreal-tournament-pinata-mutator-by-shiftre-players-will-drop-all-of-their-inventory-upon-death_[6898f69e].yml
+++ b/content/Unreal Tournament 2004/Mutators/P/6/8/98f69e/pinata2k3-is-a-remake-of-the-unreal-tournament-pinata-mutator-by-shiftre-players-will-drop-all-of-their-inventory-upon-death_[6898f69e].yml
@@ -1,0 +1,33 @@
+--- !<MUTATOR>
+contentType: "MUTATOR"
+firstIndex: "2024-02-02 13:43"
+game: "Unreal Tournament 2004"
+name: "Pinata2k3 is a remake of the Unreal Tournament Pinata mutator by shiftre. \
+  \ Players will drop all of their inventory upon death."
+author: "SlayerDragon (CSchamm@aol.com)"
+description: ""
+releaseDate: "2003-04"
+attachments: []
+originalFilename: "pinata2k3_v1_1b.zip"
+hash: "6898f69efc9d222c3d83bc510f19a1d51417d5aa"
+fileSize: 7919
+files:
+- name: "Pinata.u"
+  fileSize: 16017
+  hash: "19a7f04132d29582fd61d1a53ff705983b823ccc"
+otherFiles: 2
+dependencies: {}
+downloads:
+- url: "https://unreal-archive-files-s3.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/Mutators/P/6/8/98f69e/pinata2k3_v1_1b.zip"
+  direct: true
+  state: "OK"
+links: {}
+deleted: false
+mutators:
+- name: "Pinata2k3 is a remake of the Unreal Tournament Pinata mutator by shiftre.\
+    \  Players will drop all of their inventory upon death."
+  description: ""
+weapons: []
+vehicles: []
+hasConfigMenu: false
+hasKeybinds: false

--- a/content/Unreal Tournament 2004/Mutators/P/6/8/98f69e/pinata2k3_[6898f69e].yml
+++ b/content/Unreal Tournament 2004/Mutators/P/6/8/98f69e/pinata2k3_[6898f69e].yml
@@ -2,10 +2,10 @@
 contentType: "MUTATOR"
 firstIndex: "2024-02-02 13:43"
 game: "Unreal Tournament 2004"
-name: "Pinata2k3 is a remake of the Unreal Tournament Pinata mutator by shiftre. \
-  \ Players will drop all of their inventory upon death."
+name: "Pinata2k3"
 author: "SlayerDragon (CSchamm@aol.com)"
-description: ""
+description: "Pinata2k3 is a remake of the Unreal Tournament Pinata mutator by shiftre.\
+  \ Players will drop all of their inventory upon death"
 releaseDate: "2003-04"
 attachments: []
 originalFilename: "pinata2k3_v1_1b.zip"


### PR DESCRIPTION
Add content: 
 - [UT2004 MAP] CTF-Spirit
 - [UT2004 MAP] DM-Campgrounds2003-TE
 - [UT2004 MAP] CTF-Flax
 - [UT2004 MAP] DM-curia
 - [UT2004 MAP] DM-Atrophy
 - [UT2004 MUTATOR] MutCarLaunch
 - [UT2004 MAP] CTF-Mini
 - [UT2004 MAP] CTF-Coret1999AD
 - [UT2004 MAP] DM-Citadelle
 - [UT2004 MUTATOR] Pinata2k3 is a remake of the Unreal Tournament Pinata mutator by shiftre.  Players will drop all of their inventory upon death.
 - [UT2004 MUTATOR] '-= Maps Converter CTF =-'
 - [UT2004 MAP_PACK] UTClassics
 - [UT2004 MAP] DM-1to1Morbias

---
Submission log: https://unrealarchive.org/submit/#2bf40d70