### PR TITLE
unreal-tournament-2003-de-bonus-pack-ut2modzip_116d857c

### DIFF
--- a/content/Unreal Tournament 2004/MapPacks/U/4/c/8443e8/unreal-tournament-2003-de-bonus-pack-ut2mod_[4c8443e8].yml
+++ b/content/Unreal Tournament 2004/MapPacks/U/4/c/8443e8/unreal-tournament-2003-de-bonus-pack-ut2mod_[4c8443e8].yml
@@ -1,0 +1,120 @@
+--- !<MAP_PACK>
+contentType: "MAP_PACK"
+firstIndex: "2024-03-14 02:17"
+game: "Unreal Tournament 2004"
+name: "Unreal Tournament 2003 DE Bonus Pack (UT2MOD)"
+author: "Various"
+description: "None"
+releaseDate: "2003-01"
+attachments:
+- type: "IMAGE"
+  name: "unreal-tournament-2003-de-bonus-pack-ut2mod_shot_4c8443e8_6.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/U/4/c/8443e8/unreal-tournament-2003-de-bonus-pack-ut2mod_shot_4c8443e8_6.png"
+- type: "IMAGE"
+  name: "unreal-tournament-2003-de-bonus-pack-ut2mod_shot_4c8443e8_2.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/U/4/c/8443e8/unreal-tournament-2003-de-bonus-pack-ut2mod_shot_4c8443e8_2.png"
+- type: "IMAGE"
+  name: "unreal-tournament-2003-de-bonus-pack-ut2mod_shot_4c8443e8_1.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/U/4/c/8443e8/unreal-tournament-2003-de-bonus-pack-ut2mod_shot_4c8443e8_1.png"
+- type: "IMAGE"
+  name: "unreal-tournament-2003-de-bonus-pack-ut2mod_shot_4c8443e8_4.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/U/4/c/8443e8/unreal-tournament-2003-de-bonus-pack-ut2mod_shot_4c8443e8_4.png"
+- type: "IMAGE"
+  name: "unreal-tournament-2003-de-bonus-pack-ut2mod_shot_4c8443e8_5.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/U/4/c/8443e8/unreal-tournament-2003-de-bonus-pack-ut2mod_shot_4c8443e8_5.png"
+- type: "IMAGE"
+  name: "unreal-tournament-2003-de-bonus-pack-ut2mod_shot_4c8443e8_3.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/U/4/c/8443e8/unreal-tournament-2003-de-bonus-pack-ut2mod_shot_4c8443e8_3.png"
+originalFilename: "Unreal Tournament 2003 DE Bonus Pack (UT2MOD).zip"
+hash: "4c8443e8fa21c7432afd60a78e6e5e624ffa8869"
+fileSize: 76916110
+files:
+- name: "DM-DE-Osiris2.ut2"
+  fileSize: 13171802
+  hash: "d7c2b19dcabf6650b1621c321b353ecec04978e0"
+- name: "Level11.ogg"
+  fileSize: 3324371
+  hash: "7f7e68868ce1789660098fbefb6778ae759ebdaf"
+- name: "XceptThree.utx"
+  fileSize: 39499019
+  hash: "089c0efbd2e464807ac28d6600dbdc47f1b435fd"
+- name: "CTF-DE-LavaGiant2.ut2"
+  fileSize: 9744526
+  hash: "a7e9ad545ac775281d13bc5d7539e13591485a80"
+- name: "DM-DE-Ironic.ut2"
+  fileSize: 10164887
+  hash: "e54aec185ac5c11450051a54bea5fa436d8db4cd"
+- name: "BR-DE-ElecFields.ut2"
+  fileSize: 13047300
+  hash: "3ed7aa7b16960102fbbdb8f9ab941ad7d9b1822a"
+- name: "Level15.ogg"
+  fileSize: 3634112
+  hash: "e96639dedf43b21d56820f96f28aa57976cd0068"
+- name: "Elecfeildsshine.utx"
+  fileSize: 1556794
+  hash: "a6e84527492eff0f3675bc0a8314298cee630bb1"
+- name: "CTF-DE-ElecFields.ut2"
+  fileSize: 13030222
+  hash: "a09435e0f53250b6e5f82035fbd0fa118e24bd54"
+- name: "Level7.ogg"
+  fileSize: 4305649
+  hash: "2ee0fba8c958cfee8a9356aed91f8336466ee0d6"
+- name: "DEBonus.ut2mod"
+  fileSize: 219707501
+  hash: "8763fb2d0f650c83d105e6be73d206c06dfcb41b"
+- name: "DEBonusMeshes.usx"
+  fileSize: 197121
+  hash: "822a1c0d670800f31474faf6000b0630bb72b60a"
+- name: "BP_arch1.utx"
+  fileSize: 10762499
+  hash: "440ee7ae31787a44eafee8cb2f53304a6acccc89"
+- name: "Level9.ogg"
+  fileSize: 4367931
+  hash: "a37ad0bf1f2f4c30d07f713c12cae1cc5b9b0646"
+- name: "DEBPchecker.usx"
+  fileSize: 1132997
+  hash: "de4aa81a2d9b84b0f18c989a52a4714d3fd4d656"
+- name: "Level16.ogg"
+  fileSize: 4079121
+  hash: "4fa3107877f48181bfce9e54814a448f9f9c5ccc"
+- name: "DM-DE-Grendelkeep.ut2"
+  fileSize: 26766561
+  hash: "deb14eda962d7d643f26e4b26d7756bcbd5e7db5"
+- name: "DEBonusTextures.utx"
+  fileSize: 15255505
+  hash: "d6e69319eb3a496343eba23a3b3f37b8b661e626"
+- name: "lavaskyX.utx"
+  fileSize: 45662939
+  hash: "b49b1c04830891cddfe64010166292cd493b773e"
+otherFiles: 2
+dependencies: {}
+downloads:
+- url: "https://unreal-archive-files-s3.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/U/4/c/8443e8/Unreal%20Tournament%202003%20DE%20Bonus%20Pack%20(UT2MOD).zip"
+  direct: true
+  state: "OK"
+links: {}
+deleted: false
+maps:
+- name: "DM-DE-Osiris2"
+  title: "Osiris 2"
+  author: "Dave Ewing"
+- name: "CTF-DE-LavaGiant2"
+  title: "LavaGiant 2"
+  author: "Juan Pancho 'XceptOne' Eekels"
+- name: "DM-DE-Ironic"
+  title: "Ironic"
+  author: "Bastiaan (Checker) Frank"
+- name: "BR-DE-ElecFields"
+  title: "ElecFields"
+  author: "Juan Pancho ' XceptOne' Eekels"
+- name: "DM-DE-Grendelkeep"
+  title: "Grendelkeep"
+  author: "Scott \"Goose\" McGregor"
+- name: "CTF-DE-ElecFields"
+  title: "ElecFields"
+  author: "Juan Pancho ' XceptOne' Eekels"
+gametype: "Mixed"
+themes:
+  Tech: 0.3
+  Industrial: 0.5
+  Egyptian: 0.2


### PR DESCRIPTION
Add content: 
 - [UT2004 MAP_PACK] Unreal Tournament 2003 DE Bonus Pack (UT2MOD)

---
Submission log: https://unrealarchive.org/submit/#116d857c