### PR TITLE
feuersturms-ut2004-2016-mappack-vol2zip_ed3ceffa

### DIFF
--- a/content/Unreal Tournament 2004/MapPacks/F/3/3/4e7d8f/feuersturms-ut2004-2016-mappack-vol-2_[334e7d8f].yml
+++ b/content/Unreal Tournament 2004/MapPacks/F/3/3/4e7d8f/feuersturms-ut2004-2016-mappack-vol-2_[334e7d8f].yml
@@ -1,0 +1,81 @@
+--- !<MAP_PACK>
+contentType: "MAP_PACK"
+firstIndex: "2024-08-13 09:48"
+game: "Unreal Tournament 2004"
+name: "Feuersturm's UT2004 2016 Mappack Vol 2"
+author: "Feuersturm"
+description: "None"
+releaseDate: "2016-07"
+attachments:
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_15.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/3/3/4e7d8f/feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_15.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_9.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/3/3/4e7d8f/feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_9.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_13.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/3/3/4e7d8f/feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_13.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_12.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/3/3/4e7d8f/feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_12.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_7.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/3/3/4e7d8f/feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_7.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_11.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/3/3/4e7d8f/feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_11.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_10.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/3/3/4e7d8f/feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_10.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_5.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/3/3/4e7d8f/feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_5.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_4.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/3/3/4e7d8f/feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_4.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_3.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/3/3/4e7d8f/feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_3.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_2.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/3/3/4e7d8f/feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_2.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_1.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/3/3/4e7d8f/feuersturms-ut2004-2016-mappack-vol-2_shot_334e7d8f_1.png"
+originalFilename: "Feuersturm's-UT2004-2016-Mappack-Vol.2.zip"
+hash: "334e7d8fa6d0df1db31ad587d89371961330f14f"
+fileSize: 25787753
+files:
+- name: "CTF-{Fs}-Inferno.ut2"
+  fileSize: 43525010
+  hash: "aecf4debd65222f08e4d235a0590aa710afda601"
+- name: "CTF-{Fs}-Pyramid.ut2"
+  fileSize: 20922829
+  hash: "9c15983bdcbcd0b0172093810815bb324dc242b7"
+- name: "DM-{Fs}-Pyramid.ut2"
+  fileSize: 15533732
+  hash: "adaefa7967ed589c955cae96ef391f24e39f1751"
+otherFiles: 13
+dependencies: {}
+downloads:
+- url: "https://unreal-archive-files-s3.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/3/3/4e7d8f/Feuersturm's-UT2004-2016-Mappack-Vol.2.zip"
+  direct: true
+  state: "OK"
+links: {}
+problemLinks: {}
+deleted: false
+maps:
+- name: "DM-{Fs}-Pyramid"
+  title: "Pyramid"
+  author: "Feuersturm"
+- name: "CTF-{Fs}-Inferno"
+  title: "Burn in Hell"
+  author: "Feuersturm"
+- name: "CTF-{Fs}-Pyramid"
+  title: "Pyramid"
+  author: "Feuersturm"
+gametype: "Mixed"
+themes:
+  Ancient: 0.3
+  Egyptian: 0.7

--- a/content/Unreal Tournament 2004/MapPacks/F/9/e/1f3be0/feuersturms-ut2004-2016-mappack-vol-1_[9e1f3be0].yml
+++ b/content/Unreal Tournament 2004/MapPacks/F/9/e/1f3be0/feuersturms-ut2004-2016-mappack-vol-1_[9e1f3be0].yml
@@ -1,0 +1,88 @@
+--- !<MAP_PACK>
+contentType: "MAP_PACK"
+firstIndex: "2024-08-13 09:51"
+game: "Unreal Tournament 2004"
+name: "Feuersturm's UT2004 2016 Mappack Vol 1"
+author: "Feuersturm"
+description: "None"
+releaseDate: "2016-04"
+attachments:
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_5.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/9/e/1f3be0/feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_5.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_14.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/9/e/1f3be0/feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_14.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_4.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/9/e/1f3be0/feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_4.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_13.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/9/e/1f3be0/feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_13.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_3.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/9/e/1f3be0/feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_3.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_12.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/9/e/1f3be0/feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_12.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_2.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/9/e/1f3be0/feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_2.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_11.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/9/e/1f3be0/feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_11.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_1.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/9/e/1f3be0/feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_1.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_10.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/9/e/1f3be0/feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_10.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_9.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/9/e/1f3be0/feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_9.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_8.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/9/e/1f3be0/feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_8.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_7.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/9/e/1f3be0/feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_7.png"
+- type: "IMAGE"
+  name: "feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_6.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/9/e/1f3be0/feuersturms-ut2004-2016-mappack-vol-1_shot_9e1f3be0_6.png"
+originalFilename: "Feuersturm's-UT2004-2016-Mappack-Vol.1.zip"
+hash: "9e1f3be0f5f46bb88acef101f050d73a7ce1282c"
+fileSize: 19038567
+files:
+- name: "ONS-{Fs}-Vulcan.ut2"
+  fileSize: 11876791
+  hash: "c065a26ba74ab5582c8bf998e98a52b302585dd7"
+- name: "CTF-{Fs}-TheCore.ut2"
+  fileSize: 13277380
+  hash: "b3238a889657edeefdbe7f34fa9701e0d595808a"
+- name: "CTF-{Fs}-Faceing-Island.ut2"
+  fileSize: 24503067
+  hash: "1425b00e670841366c6061c4902d354840f15612"
+otherFiles: 12
+dependencies: {}
+downloads:
+- url: "https://unreal-archive-files-s3.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/F/9/e/1f3be0/Feuersturm's-UT2004-2016-Mappack-Vol.1.zip"
+  direct: true
+  state: "OK"
+links: {}
+problemLinks: {}
+deleted: false
+maps:
+- name: "ONS-{Fs}-Vulcan"
+  title: "Vulcan"
+  author: "Feuersturm"
+- name: "CTF-{Fs}-TheCore"
+  title: "The Core"
+  author: "Feuersturm"
+- name: "CTF-{Fs}-Faceing-Island"
+  title: "Facing Island"
+  author: "Feuersturm"
+gametype: "Mixed"
+themes:
+  Natural: 0.3
+  Tech: 0.3
+  Ancient: 0.3

--- a/content/Unreal Tournament 2004/MapPacks/O/6/d/2f565e/overdose-remix_[6d2f565e].yml
+++ b/content/Unreal Tournament 2004/MapPacks/O/6/d/2f565e/overdose-remix_[6d2f565e].yml
@@ -1,0 +1,50 @@
+--- !<MAP_PACK>
+contentType: "MAP_PACK"
+firstIndex: "2024-08-13 09:52"
+game: "Unreal Tournament 2004"
+name: "Overdose RemiX"
+author: "UEM"
+description: "None"
+releaseDate: "2009-03"
+attachments:
+- type: "IMAGE"
+  name: "overdose-remix_shot_6d2f565e_3.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/O/6/d/2f565e/overdose-remix_shot_6d2f565e_3.png"
+- type: "IMAGE"
+  name: "overdose-remix_shot_6d2f565e_2.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/O/6/d/2f565e/overdose-remix_shot_6d2f565e_2.png"
+- type: "IMAGE"
+  name: "overdose-remix_shot_6d2f565e_1.png"
+  url: "https://ua-img.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/O/6/d/2f565e/overdose-remix_shot_6d2f565e_1.png"
+originalFilename: "Overdose_RemiX.rar"
+hash: "6d2f565ef180615595fad477edcd9efde111c252"
+fileSize: 16586385
+files:
+- name: "overdose.ogg"
+  fileSize: 6472403
+  hash: "dbf70e9e09cbd234141d6fa4a57afdd460edc4b2"
+- name: "CTF-{UEM}-Overdose_RemiX.ut2"
+  fileSize: 22520606
+  hash: "aad24f031248e8d7333052f52e29cb02798ce3bb"
+- name: "BR-{UEM}-Overdose_RemiX.ut2"
+  fileSize: 21577026
+  hash: "fe50a879b1ff108fe74228120ed0fbf1bb105fc3"
+otherFiles: 2
+dependencies: {}
+downloads:
+- url: "https://unreal-archive-files-s3.s3.us-west-002.backblazeb2.com/Unreal%20Tournament%202004/MapPacks/O/6/d/2f565e/Overdose_RemiX.rar"
+  direct: true
+  state: "OK"
+links: {}
+problemLinks: {}
+deleted: false
+maps:
+- name: "CTF-{UEM}-Overdose_RemiX"
+  title: "Overdose"
+  author: "UEM"
+- name: "BR-{UEM}-Overdose_RemiX"
+  title: "Overdose"
+  author: "UEM"
+gametype: "Mixed"
+themes:
+  Tech: 1.0


### PR DESCRIPTION
Add content: 
 - [UT2004 MAP_PACK] Feuersturm's UT2004 2016 Mappack Vol 2
 - [UT2004 MAP_PACK] Feuersturm's UT2004 2016 Mappack Vol 1
 - [UT2004 MAP_PACK] Overdose RemiX

---
Submission log: https://unrealarchive.org/submit/#ed3ceffa