### PR TITLE
UT2003 map fixes

### DIFF
--- a/content/Unreal Tournament 2004/Maps/Bombing Run/O/1/2/6cd1c3/br-onuris_[126cd1c3].yml
+++ b/content/Unreal Tournament 2004/Maps/Bombing Run/O/1/2/6cd1c3/br-onuris_[126cd1c3].yml
@@ -4,9 +4,8 @@ firstIndex: "2018-10-21 00:05"
 game: "Unreal Tournament 2004"
 name: "BR-Onuris"
 author: "Mercenary"
-description: "Onuris is the latest discovered temple of the ancient ball game.  Because\
-  \ the players wanted to go back t"
-releaseDate: "2001-01"
+description: "Onuris is the latest discovered temple of the ancient ball game.  Because the players wanted to go back to the roots of this game, they started to use the arena again..."
+releaseDate: "2004-12-30"
 attachments:
 - type: "IMAGE"
   name: "BR-Onuris_shot_4.png"

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/F/8/7/561486/ctf-forsakkensky2003_sdwp-final_[87561486].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/F/8/7/561486/ctf-forsakkensky2003_sdwp-final_[87561486].yml
@@ -1,7 +1,7 @@
 --- !<MAP>
 contentType: "MAP"
 firstIndex: "2023-11-01 00:47"
-game: "Unreal Tournament 2004"
+game: "Unreal Tournament 2003"
 name: "CTF-ForsakkenSky2003_SDWP-Final"
 author: "{SDWP}Syphir -- syfusion@hotmail.com"
 description: "None"

--- a/content/Unreal Tournament 2004/Maps/Capture The Flag/F/f/a/d397f4/ctf-forsakkensky2003_sdwp_[fad397f4].yml
+++ b/content/Unreal Tournament 2004/Maps/Capture The Flag/F/f/a/d397f4/ctf-forsakkensky2003_sdwp_[fad397f4].yml
@@ -1,7 +1,7 @@
 --- !<MAP>
 contentType: "MAP"
 firstIndex: "2023-10-10 14:08"
-game: "Unreal Tournament 2004"
+game: "Unreal Tournament 2003"
 name: "CTF-ForsakkenSky2003_SDWP"
 author: "{SDWP}Syphir -- syfusion@hotmail.com"
 description: "None"


### PR DESCRIPTION
* Switched Unreal Tournament 2004 to Unreal Tournament 2003 in many maps made before 2004-03-16 (the release date of UT2004, [source](https://unreal.fandom.com/wiki/Unreal_Tournament_2004)). The maps picked up, however, were those whose release date predates the release date of UT2003 (October 1, 2002, [source](https://unreal.fandom.com/wiki/Unreal_Tournament_2003))
* Fixed release dates based on Readme and file info
* Fixed some descriptions.