### PR TITLE
Content: btfa_v107z_e60dd4a2

### DIFF
--- a/content/Unreal Tournament 3/Mutators/B/9/c/a74a09/btfa-v10_[9ca74a09].yml
+++ b/content/Unreal Tournament 3/Mutators/B/9/c/a74a09/btfa-v10_[9ca74a09].yml
@@ -1,0 +1,36 @@
+--- !<MUTATOR>
+contentType: "MUTATOR"
+firstIndex: "2026-04-25 13:40"
+game: "Unreal Tournament 3"
+name: "BTFA V10"
+author: "Nico de Vries"
+description: "None"
+releaseDate: "2009-06"
+attachments: []
+originalFilename: "BTFA_V10.7z"
+hash: "9ca74a0929335eae9b636a32e609dffb63097b77"
+fileSize: 1774208
+files:
+- name: "BattleTeamArenaContent.upk"
+  fileSize: 3560056
+  hash: "df633f87e6e21491cc44da2fe826db909e71c577"
+- name: "BattleTeamArena.u"
+  fileSize: 515283
+  hash: "4ee793bc128156c5efd3f4c9f8f8c3cfc36f7b01"
+otherFiles: 3
+dependencies:
+  BattleTeamArena.u:
+  - status: "OK"
+    name: "BattleTeamArenaContent"
+downloads:
+- url: "https://unreal-archive-files-eu.s3.de.io.cloud.ovh.net/Unreal%20Tournament%203/Mutators/B/9/c/a74a09/BTFA_V10.7z"
+  direct: true
+  state: "OK"
+links: {}
+problemLinks: {}
+deleted: false
+mutators: []
+weapons: []
+vehicles: []
+hasConfigMenu: false
+hasKeybinds: false


### PR DESCRIPTION
Add content: 
 - [UT3 MUTATOR] 'BTFA V10' by 'Nico de Vries' [9ca74a09, Original]

---
Job log:
```
[I 0.00s] Job created with ID e60dd4a2
[I 0.00s] Content type is forced to MUTATOR
[I 0.01s] Received file(s): BTFA_V10.7z, queue for processing
[I 0.01s] Picked up for processing
[I 0.01s] Scanning for malware
[I 18.33s] No malware found
[I 18.33s] Picked up for processing
[I 18.33s] Content scan skipped, forcing type to MUTATOR
[I 18.33s] Picked up for processing
[I 18.33s] Checkout content data branch btfa_v107z_e60dd4a2
[I 28.35s] Indexed MUTATOR: BTFA V10 by Nico de Vries
[I 28.35s] Indexing complete
[I 28.35s] Submitting content and opening pull request
[I 41.47s] Commit changes to content data
[I 41.97s] Push content data changes ...
[I 44.33s] Content data changes pushed
```

---
Submission log: https://unrealarchive.org/submit/#e60dd4a2