### PR TITLE
Content: dm-1v1-ruinlockrar_82c6eb00

### DIFF
--- a/content/Unreal Tournament/Maps/DeathMatch/0/8/3/6c11eb/dm-1vs1-ruinlock_[836c11eb].yml
+++ b/content/Unreal Tournament/Maps/DeathMatch/0/8/3/6c11eb/dm-1vs1-ruinlock_[836c11eb].yml
@@ -1,0 +1,38 @@
+--- !<MAP>
+contentType: "MAP"
+firstIndex: "2026-07-07 23:26"
+game: "Unreal Tournament"
+name: "DM-1vs1-RuinLock"
+author: "UniversoWeb"
+description: "R\0u\0i\0n\0L\0o\0c\0k\0 \0f\0u\0e\0 \0c\0o\0n\0v\0e\0r\0t\0i\0d\0a\0\
+  \ \0e\0n\0 \0a\0r\0e\0n\0a\0 \0d\0e\0 \0d\0u\0e\0l\0o\0 \0t\0r\0a\0s\0 \0u\0n\0\
+  \ \0c\0o\0m\0b\0a\0t\0e\0 \0d\0e\0 \0p\0r\0u\0e\0b\0a\0 \0q\0u\0e\0 \0t\0e\0r\0\
+  m\0i\0n\0ó\0 \0e\0n\0 \0c\0o\0l\0a\0p\0s\0o\0.\0\0\0l"
+releaseDate: "2026-06"
+attachments:
+- type: "IMAGE"
+  name: "dm-1vs1-ruinlock_shot_836c11eb_1.png"
+  url: "https://unreal-archive-img.s3.sgp.io.cloud.ovh.net/Unreal%20Tournament/Maps/DeathMatch/0/8/3/6c11eb/dm-1vs1-ruinlock_shot_836c11eb_1.png"
+originalFilename: "DM-1v1-Ruinlock.rar"
+hash: "836c11eb6753393f0630342e5f16e87831738f97"
+fileSize: 188602
+files:
+- name: "DM-1vs1-RuinLock.unr"
+  fileSize: 445756
+  hash: "6704e5659a49d01a1d8289ac84474233e5549c39"
+otherFiles: 1
+dependencies: {}
+downloads:
+- url: "https://unreal-archive-files-eu.s3.de.io.cloud.ovh.net/Unreal%20Tournament/Maps/DeathMatch/0/8/3/6c11eb/DM-1v1-Ruinlock.rar"
+  direct: true
+  state: "OK"
+links: {}
+problemLinks: {}
+deleted: false
+gametype: "DeathMatch"
+title: "DM-1vs1-Ruinlock"
+playerCount: "2"
+themes:
+  Nali Temple: 0.2
+  Natural: 0.8
+bots: true


### PR DESCRIPTION
Add content: 
 - [UT99 MAP] 'DM-1vs1-RuinLock' by 'UniversoWeb' [836c11eb, Original]

---
Job log:
```
[I 0.00s] Job created with ID 82c6eb00
[I 0.00s] Received file(s): DM-1v1-Ruinlock.rar, queue for processing
[I 0.00s] Picked up for processing
[I 0.00s] Scanning for malware
[I 15.08s] No malware found
[I 15.08s] Picked up for processing
[I 15.08s] Begin scanning content
[I 15.11s] Found a MAP in file DM-1v1-Ruinlock.rar
[I 15.11s] Scan completed
[I 15.11s] Picked up for processing
[I 15.11s] Checkout content data branch dm-1v1-ruinlockrar_82c6eb00
[I 32.70s] Indexed MAP: DM-1vs1-RuinLock by UniversoWeb
[I 32.70s] Indexing complete
[I 32.70s] Submitting content and opening pull request
[I 45.16s] Commit changes to content data
[I 45.73s] Push content data changes ...
[I 48.99s] Content data changes pushed
```

---
Submission log: https://unrealarchive.org/submit/#82c6eb00